### PR TITLE
patch for pool->kinfo_pool changes in OpenBSD

### DIFF
--- a/stats.c
+++ b/stats.c
@@ -36,6 +36,7 @@
 #include <sys/mbuf.h>
 #include <sys/protosw.h>
 #include <sys/sysctl.h>
+#include <sys/pool.h>
 #include <errno.h>
 
 #include <net/route.h>
@@ -83,7 +84,7 @@ static int sflag = 1;
 typedef int bool;
 
 struct  mbstat mbstat;
-struct pool mbpool, mclpool;
+struct kinfo_pool mbpool, mclpool;
 
 #ifdef INET6
 char	*inet6name(struct in6_addr *);
@@ -776,7 +777,7 @@ mbpr(void)
 	int totmem, totused, totmbufs, totpct;
 	int i, mib[4], npools, flag = 0;
 	bool seen[256];
-	struct pool pool;
+	struct kinfo_pool pool;
 	struct mbtypes *mp;
 	size_t size;
 	int page_size = getpagesize();
@@ -813,7 +814,7 @@ mbpr(void)
 		mib[1] = KERN_POOL;
 		mib[2] = KERN_POOL_POOL;
 		mib[3] = i;
-		size = sizeof(struct pool);
+		size = sizeof(struct kinfo_pool);
 		if (sysctl(mib, 4, &pool, &size, NULL, 0) < 0) {
 			if (errno == ENOENT)
 				continue;
@@ -831,12 +832,12 @@ mbpr(void)
 		}
 
 		if (!strncmp(name, "mbpl", strlen("mbpl"))) {
-			bcopy(&pool, &mbpool, sizeof(struct pool));
+			bcopy(&pool, &mbpool, sizeof(struct kinfo_pool));
 			flag++;
 		} else {
 			if (!strncmp(name, "mclpl", strlen("mclpl"))) {
 				bcopy(&pool, &mclpool,
-				    sizeof(struct pool));
+				    sizeof(struct kinfo_pool));
 				flag++;
 			}
 		}


### PR DESCRIPTION
OpenBSD 5.6 now uses struct kinfo_pool (not struct pool) in userland.