### PR TITLE
Update externs.h

### DIFF
--- a/externs.h
+++ b/externs.h
@@ -237,7 +237,17 @@ void flag_x(char *, char *, int, char *);
 #define PKILL		"/usr/bin/pkill"
 #define SAVESCRIPT	"/usr/local/bin/save.sh"
 /* tmp config locations */
+/*
+DHCPDB must allow being defined externally, because DHCPLEASES already allows that
+and things break when it points elsewhere
+
+  make CFLAGS="-DDHCPLEASES=\\\"/flash/dhcpd.leases\\\" \
+               -DDHCPDB=\\\"/flash/dhcpd.leases\\\""
+
+*/
+#ifndef DHCPDB
 #define DHCPDB          "/var/db/dhcpd.leases"
+#endif
 void command(void);
 char **step_optreq(char **, char **, int, char **, int);
 int argvtostring(int, char **, char *, int);


### PR DESCRIPTION
I made a router using OpenBSD+flashrd+NSH and found the command "SHOW DHCP LEASES" complaining about the file /var/db/dhcpd.leases wasn't on their place.
I built with -DDHCPLEASES=\\\"/flash/dhcpd.leases\\\" and dhcpd was working as expected.
After some digging I found the above path hardcoded in externs.h so I edited it making its definition conditional and the issue is gone.
If you feel it worth merging, please go ahead.
