### PR TITLE
fix crash when running reboot and halt

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1897,7 +1897,7 @@ nreboot(void)
 	printf ("%% Reboot initiated\n");
 	if (reboot (RB_AUTOBOOT) == -1)
 		printf("%% reboot: RB_AUTOBOOT: %s\n", strerror(errno));
-	return(1);
+	return(0);
 }
                
 int
@@ -1906,7 +1906,7 @@ halt(void)
 	printf ("%% Shutdown initiated\n");
 	if (reboot (RB_HALT) == -1)
 		printf("%% reboot: RB_HALT: %s\n", strerror(errno));
-	return(1);
+	return(0);
 }
 
 /*


### PR DESCRIPTION
nsh will not properly run halt and reboot which results in crash upon running 'halt' and 'reboot'.