### PR TITLE
Add 'sh ipsec sadb/flows'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ PROG= nsh
 
 # For use with flashrd:
 #CFLAGS=-O -DDHCPLEASES=\"/flash/dhcpd.leases\" -Wmissing-prototypes -Wformat -Wall -Wpointer-arith -Wbad-function-cast #-W
-CFLAGS=-O -Wmissing-prototypes -Wformat -Wall -Wpointer-arith -Wbad-function-cast #-W
+CFLAGS?=-O
+CFLAGS+=-Wmissing-prototypes -Wformat -Wall -Wpointer-arith -Wbad-function-cast #-W
 
 SRCS=arp.c compile.c main.c genget.c commands.c stats.c kroute.c
 SRCS+=ctl.c show.c if.c version.c route.c conf.c complete.c ieee80211.c

--- a/commands.c
+++ b/commands.c
@@ -168,6 +168,7 @@ Menu showlist[] = {
 	{ "rip",	"RIP information",	CMPL(ta) (char **)rics, sizeof(struct prot1), 0, 3, pr_prot1 },
 	{ "ldp",	"LDP information",	CMPL(ta) (char **)lics, sizeof(struct prot1), 0, 3, pr_prot1 },
 	{ "ike",	"IKE information",	CMPL(ta) (char **)ikcs, sizeof(struct prot1), 0, 3, pr_prot1 },
+	{ "ipsec",	"IPsec information",	CMPL(ta) (char **)iscs, sizeof(struct prot1), 0, 1, pr_prot1 },
 	{ "dvmrp",	"DVMRP information",	CMPL(ta) (char **)dvcs, sizeof(struct prot1), 0, 2, pr_prot1 },
 	{ "relay",	"Relay server",		CMPL(ta) (char **)rlcs, sizeof(struct prot1), 0, 1, pr_prot1 },
 	{ "dhcp",	"DHCP server",		CMPL(ta) (char **)dhcs, sizeof(struct prot1), 0, 1, pr_dhcp },

--- a/commands.h
+++ b/commands.h
@@ -135,6 +135,14 @@ struct prot1 lics[] = {
 	{ 0, 0, { 0 } }
 };
 
+struct prot1 iscs[] = {
+	{ "flows",	"Display IPsec flows",
+	    { IPSECCTL, "-sf", NULL } },
+	{ "sadb",	"Display SADB",
+	    { IPSECCTL, "-ss", NULL } },
+	{ 0, 0, { 0 } }
+};
+
 struct prot1 ikcs[] = {
 	{ "monitor",	"Monitor internal iked messages",
 	    { IKECTL, "monitor", NULL } },
@@ -199,6 +207,7 @@ struct prot prots[] = {
 	{ "ospf6",	os6cs },
 	{ "rip",	rics },
 	{ "ike",	ikcs },
+	{ "ipsec",	iscs },
 	{ "ldp",	lics },
 	{ "dvmrp",	dvcs },
 	{ "relay",	rlcs },


### PR DESCRIPTION
Since OpenBSD no longer includes flows in the normal route table we need a different way to see them.

Bonus diff while there to honour the user's cflags (to remove a patch from the port).