### PR TITLE
set Makefile defaults to have 'make install' work out of the box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 #
 PROG= nsh
 
+DESTDIR?=/usr/local
+BINDIR?=/bin
+MANDIR?=/man/man
+
 # For use with flashrd:
 #CFLAGS=-O -DDHCPLEASES=\"/flash/dhcpd.leases\" -Wmissing-prototypes -Wformat -Wall -Wpointer-arith -Wbad-function-cast #-W
 CFLAGS?=-O


### PR DESCRIPTION
Before:

  # make -n install
  install -c -s  -o root -g bin  -m 555 nsh /nsh
  install -c -o root -g bin -m 444  /home/stsp/src/nsh/nsh.8 /usr/share/man/man8/nsh.8

After:

 # make -n install
 install -c -s  -o root -g bin  -m 555 nsh /usr/local/bin/nsh
 install -c -o root -g bin -m 444  /home/stsp/src/nsh/nsh.8 /usr/local/man/man8/nsh.8