### PR TITLE
directly set the IFXF_AUTOCONF4 flag if dhcpleased(8) is running

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -518,6 +518,9 @@ struct intlist Intlist[] = {
 /* Interface mode commands */
 	{ "ip",		"IP address and other parameters",	CMPL0 0, 0, intip },
 	{ "alias",	"Additional IP addresses and other parameters", CMPL0 0, 0, intip },
+#ifdef IFXF_AUTOCONF4		/* 6.6+ */
+	{ "autoconf4",  "IPv4 Autoconfigurable address",	CMPL0 0, 0, intxflags },
+#endif
 	{ "description", "Interface description",		CMPL0 0, 0, intdesc },
 	{ "group",	"Interface group",			CMPL0 0, 0, intgroup },
 	{ "rdomain",	"Interface routing domain",		CMPL0 0, 0, intrdomain },

--- a/externs.h
+++ b/externs.h
@@ -368,6 +368,7 @@ int parse_ipv6(char *, struct in6_addr *);
 #define DHCLIENT	"/sbin/dhclient"
 #define DHCRELAY	"/usr/sbin/dhcrelay"
 #define RAD		"/usr/sbin/rad"
+#define DHCPLEASED_SOCK	"/dev/dhcpleased.sock"
 #define IFDATA_MTU 1		/* request for if_data.ifi_mtu */
 #define IFDATA_BAUDRATE 2	/* request for if_data.ifi_baudrate */
 #define MBPS(bps) (bps / 1000 / 1000)
@@ -413,6 +414,7 @@ int intpwe3(char *, int, int, char **);
 int intvnetflowid(char *, int, int, char **);
 int addaf(char *, int, int);
 int removeaf(char *, int, int);
+int dhcpleased_is_running(void);
 char *get_hwdaddr(char *);
 
 /* main.c */


### PR DESCRIPTION
As of OpenBSD 7.2 dhclient is a stub which sets the IFXF_AUTOCONF4 flag for dhcpleased. Prepare nsh for a future after rm /sbin/dhclient by checking if dhcpleased is running and directly setting the flag if it is.

This is a first future-proofing step. Further changes will be required for full dhcpleased support in nsh. For example, write-config will currently write out a leased IP as if it was a static IP.

As a side effect this adds a new "autoconf4" command, which only works on systems running dhcpleased. For now, I have left this undocumented in the man page, since users can simply keep configuring DHCP as usual. In the future, the man page should probably at least mention it, though, because this command now appears in the user's tab-completion list.