### PR TITLE
fix build error: don't know how to make /usr/local/usr/lib/crt0.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 #
 PROG= nsh
 
+.if make(install)
 DESTDIR?=/usr/local
 BINDIR?=/bin
 MANDIR?=/man/man
+.endif
 
 # For use with flashrd:
 #CFLAGS=-O -DDHCPLEASES=\"/flash/dhcpd.leases\" -Wmissing-prototypes -Wformat -Wall -Wpointer-arith -Wbad-function-cast #-W


### PR DESCRIPTION
When I added defaults for 'make install' I forgot to test a build after 'make clean'. Turns out setting DESTDIR like I did will cause an error during regular builds:
make: don't know how to make /usr/local/usr/lib/crt0.o (prerequisite of: nsh)

Ensure that the new default values are only used during 'make install'.