### PR TITLE
add nameserver command to manage static DNS nameserver IPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SRCS=arp.c compile.c main.c genget.c commands.c stats.c kroute.c
 SRCS+=ctl.c show.c if.c version.c route.c conf.c complete.c ieee80211.c
 SRCS+=bridge.c tunnel.c media.c sysctl.c passwd.c pfsync.c carp.c
 SRCS+=trunk.c who.c more.c stringlist.c utils.c sqlite3.c ppp.c
-SRCS+=nopt.c pflow.c wg.c
+SRCS+=nopt.c pflow.c wg.c nameserver.c
 CLEANFILES+=compile.c
 LDADD=-ledit -ltermcap -lsqlite3 -L/usr/local/lib #-static
 

--- a/commands.c
+++ b/commands.c
@@ -864,6 +864,7 @@ static char
 #ifdef notyet
 	parphelp[] =	"Proxy ARP set",
 #endif
+	nameserverhelp[] ="set or remove static DNS nameservers",
 	pfhelp[] =	"Packet filter control",
 	ospfhelp[] =	"OSPF control",
 	ospf6help[] = 	"OSPF6 control",
@@ -933,6 +934,7 @@ Command cmdtab[] = {
 #ifdef notyet
 	{ "proxy-arp",	parphelp,	CMPL0 0, 0, arpset,	1, 1, 0 },
 #endif
+	{ "nameserver",	nameserverhelp,	CMPL0 0, 0, nameserverset,1, 1, 0 },
 	{ "bridge",	bridgehelp,	CMPL(i) 0, 0, interface, 1, 1, 1 },
 	{ "show",	showhelp,	CMPL(ta) (char **)showlist, sizeof(Menu), showcmd,	0, 0, 0 },
 	{ "ip",		iphelp,		CMPL(ta) (char **)iptab, sizeof(Menu), ipcmd,		1, 1, 0 },

--- a/conf.c
+++ b/conf.c
@@ -232,6 +232,9 @@ conf(FILE *output)
 
 	conf_rtables(output);
 
+	fprintf(output, "!\n");
+	conf_nameserver(output);
+
 	return(0);
 }
 

--- a/externs.h
+++ b/externs.h
@@ -364,6 +364,7 @@ int is_ip_addr(char *);
 void parse_ip_pfx(char *, int, ip_t *);
 int ip_route(ip_t *, ip_t *, u_short, int, int, struct rt_metrics, int inits);
 #endif
+int rtnameserver(int, char *[], int);
 #ifdef _NETINET6_IN6_H_
 int parse_ipv6(char *, struct in6_addr *);
 #endif
@@ -513,6 +514,10 @@ void arpdump(void);
 void conf_arp(FILE *, char *);
 char *sec2str(time_t);
 
+/* nameserver.c */
+int nameserverset(int, char **);
+void conf_nameserver(FILE *);
+
 /* more.c */
 int more(char *);
 int nsh_cbreak(void);
@@ -546,11 +551,14 @@ char *format_k(uint64_t amt);
 #define DB_X_DISABLE_ALWAYS 7	/* disable command, always prints if disabled */
 int db_create_table_rtables(void);
 int db_create_table_flag_x(char *);
+int db_create_table_nameservers(void);
 int db_insert_flag_x(char *, char *, int, int, char *);
 int db_insert_rtables(int, char *);
+int db_insert_nameserver(char *);
 int db_delete_rtables_rtable(int);
 int db_delete_flag_x_ctl(char *, char *);
 int db_delete_flag_x_ctl_data(char *, char *, char *);
+int db_delete_nameservers(void);
 #ifdef _STRINGLIST_H
 int db_select_flag_x_ctl_data(StringList *, char *, char *, char *);
 int db_select_flag_x_ctl(StringList *, char *, char *);
@@ -560,6 +568,7 @@ int db_select_rtables_ctl(StringList *, char *);
 int db_select_name_rtable(StringList *, int);
 int db_select_flag_x_ctl_rtable(StringList *, char *, int);
 int db_select_flag_x_data_ctl_rtable(StringList *, char *, char *, int);
+int db_select_nameservers(StringList *);
 #endif
 int db_select_flag_x_dbflag_rtable(char *, char *, int);
 

--- a/main.c
+++ b/main.c
@@ -105,6 +105,8 @@ main(int argc, char *argv[])
 		printf("%% database authkey creation failed\n");
 	if (db_create_table_flag_x("peerkey") < 0)
 		printf("%% database peerkey creation failed\n");
+	if (db_create_table_nameservers() < 0)
+		printf("%% database nameservers creation failed\n");
 
 	if (iflag) {
 		/*

--- a/nameserver.c
+++ b/nameserver.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2023 Stefan Sperling <stsp@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "stringlist.h"
+#include "externs.h"
+
+int nameserver_usage(void);
+int nameserver4_valid(char *);
+int nameserver6_valid(char *);
+int resolvd_is_disabled(void);
+
+int
+nameserver_usage(void)
+{
+	printf("%% nameserver address ... (up to 5 addresses)\n");
+	printf("%% no nameserver\n");
+	return (0);
+}
+
+int
+nameserver4_valid(char *addrstr)
+{
+	struct in_addr addr4;
+	int ret;
+
+	ret = inet_pton(AF_INET, addrstr, &addr4);
+	if (ret == -1) {
+		printf("%% inet_pton: %s", strerror(errno));
+		return (0);
+	}
+	return (ret == 1);
+}
+
+int
+nameserver6_valid(char *addrstr)
+{
+	struct in6_addr addr6;
+	int ret;
+
+	ret = inet_pton(AF_INET6, addrstr, &addr6);
+	if (ret == -1) {
+		printf("%% inet_pton: %s", strerror(errno));
+		return (0);
+	}
+	return (ret == 1);
+}
+
+int
+resolvd_is_disabled(void)
+{
+	int dbflag = db_select_flag_x_dbflag_rtable("ctl", "resolvd", 0);
+	return (dbflag == DB_X_DISABLE_ALWAYS); 
+}
+
+int
+nameserverset(int argc, char *argv[])
+{
+	int i, set = 1;
+
+	if (argc < 2)
+		return nameserver_usage();
+
+	if (NO_ARG(argv[0])) {
+		argv++;
+		argc--;
+		if (argc != 1)
+			return nameserver_usage();
+		set = 0;
+	} else {
+		if (argc > 6)
+			return nameserver_usage();
+
+		for (i = 1; i < argc; i++) {
+			if (!nameserver4_valid(argv[i]) &&
+			    !nameserver6_valid(argv[i])) {
+				printf("%% invalid address: %s\n", argv[i]);
+				return (1);
+			}
+		}
+	}
+
+	/*
+	 * Always clear existing nameservers, even before setting new ones.
+	 * resolvd will do likewise when it receives new proposals for lo0.
+	 * So this ensures consistency between the nameservers table in our
+	 * DB and /etc/resolv.conf.
+	 */
+	if (db_delete_nameservers() < 0) {
+		printf("%% nameservers db deletion error\n");
+		return (1);
+	}
+
+	if (set) {
+		for (i = 1; i < argc; i++) {
+			if (db_insert_nameserver(argv[i]) < 0) {
+				printf("%% nameservers db insertion error\n");
+				return (1);
+			}
+		}
+	}
+
+	argv[0] = "lo0";
+	return rtnameserver(argc, argv, 0 /* always use rtable 0 */);
+}
+
+void
+conf_nameserver(FILE *output)
+{
+	StringList *nameservers;
+	int i;
+
+	nameservers = sl_init();
+
+	if (db_select_nameservers(nameservers) < 0) {
+		printf("%% database failure select nameservers\n");
+		sl_free(nameservers, 1);
+		return;
+	}
+
+	if (nameservers->sl_cur > 0) {
+		fprintf(output, "nameserver");
+		for (i = 0; i < nameservers->sl_cur; i++)
+			fprintf(output, " %s", nameservers->sl_str[i]);
+		fprintf(output, "\n");
+	}
+
+	sl_free(nameservers, 1);
+}

--- a/sqlite3.c
+++ b/sqlite3.c
@@ -34,6 +34,13 @@ db_create_table_rtables(void)
 }
 
 int
+db_create_table_nameservers(void)
+{
+	char query[]="CREATE TABLE IF NOT EXISTS nameservers (nameserver TEXT)";
+	return(sq3simple(query, NULL));
+}
+
+int
 db_create_table_flag_x(char *name)
 {
 	char		query[QSZ];
@@ -72,6 +79,16 @@ db_delete_rtables_rtable(int rtableid)
 }
 
 int
+db_insert_nameserver(char *nameserver)
+{
+	char		query[QSZ];
+
+	snprintf(query, QSZ, "INSERT OR REPLACE INTO 'nameservers' VALUES('%s')",
+	    nameserver);
+	return(sq3simple(query, NULL));
+}
+
+int
 db_delete_flag_x_ctl(char *name, char *ctl)
 {
 	char		query[QSZ];
@@ -86,6 +103,15 @@ db_delete_flag_x_ctl_data(char *name, char *ctl, char *data)
 	char		query[QSZ];
 
 	snprintf(query, QSZ, "DELETE FROM '%s' WHERE ctl='%s' AND data='%s'", name, ctl, data);
+	return(sq3simple(query, NULL));
+}
+
+int
+db_delete_nameservers(void)
+{
+	char		query[QSZ];
+
+	snprintf(query, QSZ, "DELETE FROM 'nameservers'");
 	return(sq3simple(query, NULL));
 }
 
@@ -165,6 +191,13 @@ db_select_flag_x_dbflag_rtable(char *name, char *ctl, int rtableid)
 	sl_free(words, 1);
 
 	return rv;
+}
+
+int
+db_select_nameservers(StringList *words)
+{
+	char query[]="SELECT nameserver FROM nameservers";
+	return(sq3simple(query, words));
 }
 
 int


### PR DESCRIPTION
The nameserver command accepts up to 5 IPv4 or IPv6 addresses and will propose these nameservers to resolvd(8) by running /sbin/route.

Nameservers learned by other means such as DHCP will co-exist peacefully, though the ultimate decision about which nameservers /etc/resolv.conf will contain is entirely up to resolvd.

The route nameserver command requires a network interface which the proposed nameservers belong to. We use lo0 for this purpose since lo0 is unlikely to be used by other daemons which produce nameserver proposals.

The /sbin/route command is also able to remove all nameservers associated with an interface. This is mapped to the "no nameserver" command, which removes all static nameservers configured for lo0 from /etc/resolv.conf.