### PR TITLE
adjust inputs which exit the "interface" command scope

### DIFF
--- a/complete.c
+++ b/complete.c
@@ -478,6 +478,7 @@ initedit()
 		el_set(eli, EL_BIND, "\t", "complt_i", NULL);
 		el_set(eli, EL_ADDFN, "exit_i", "Exit", exit_i);
 		el_set(eli, EL_BIND, "^X", "exit_i", NULL);
+		el_set(eli, EL_BIND, "^D", "exit_i", NULL);
 		el_source(eli, NULL);
 		el_set(eli, EL_SIGNAL, 1);
 	}


### PR DESCRIPTION
Exit the interface command scope upon reading ^X, ^D, "exit", or "..", instead of Enter.

Exiting the scope upon Enter can be confusing or unintended. ^X was already working. Add "..", ^D, and "exit" as shell idioms which users might try intuitively.

Factor code which reads command lines out of the interface command implementation to allow for potential reuse in other contexts, adding sanity checks to catch non-printable garbage input characters.

Based on suggestions from Tom Smyth.