### PR TITLE
ensure makeargv() produced some arguments before dereferencing margv[0]

### DIFF
--- a/complete.c
+++ b/complete.c
@@ -307,7 +307,7 @@ complete(EditLine *el, int ch, char **table, size_t stlen, char *arg)
 	lastc_argo = cursor_argo;
 	makeargv();			/* build argc/argv of current line */
 
-	if (cursor_argo >= sizeof(word))
+	if (margc == 0 || cursor_argo >= sizeof(word))
 		return (CC_ERROR);
 
 	dolist = 0;


### PR DESCRIPTION
Otherwise tab-completion can crash in strncmp() as follows:

nsh.my.domain(p)/   s<TAB>
sasync  show    smtp    snmp    ssh     sshd
nsh.my.domain(p)/
Program received signal SIGSEGV, Segmentation fault.
_libc_strncmp (s1=Variable "s1" is not available.
) at /usr/src/lib/libc/string/strncmp.c:41
41      /usr/src/lib/libc/string/strncmp.c: No such file or directory.
        in /usr/src/lib/libc/string/strncmp.c
Current language:  auto; currently minimal
(gdb) up
    at /home/stsp/src/nsh/complete.c:317
317                 && strncmp(word, margv[cursor_argc], cursor_argo) == 0)
(gdb) p word
$1 = 0x9cccb3f9230 "s"
(gdb) p margv
$2 = 0x9cccb3f6c90
(gdb) p margv[0]
$3 = 0x0
(gdb) p cursor_argc
$4 = 0
(gdb) p cursor_argo
$5 = 1
(gdb) p line
$6 = 0x9cccb3f7ca0 "   "