### PR TITLE
use explicit casts for ctype function arguments

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1085,7 +1085,7 @@ makeargv()
 	}
 	while ((c = *cp)) {
 		int inquote = 0;
-		while (isspace(c))
+		while (isspace((unsigned char)c))
 			c = *++cp;
 		if (c == '\0')
 			break;
@@ -1109,7 +1109,7 @@ makeargv()
 				} else if (c == '\'') {
 					inquote = '\'';
 					continue;
-				} else if (isspace(c)) {
+				} else if (isspace((unsigned char)c)) {
 					cursor_argo = 0;
 					break;
 				}

--- a/genget.c
+++ b/genget.c
@@ -33,8 +33,6 @@
 #include <stdio.h>
 #include "externs.h"
 
-#define	LOWER(x) (isupper((int)x) ? tolower((int)x) : (x))
-
 int isprefix(char *, char*);
 
 /*
@@ -54,7 +52,7 @@ isprefix(char *s1, char *s2)
     os1 = s1;
     c1 = *s1;
     c2 = *s2;
-    while (LOWER(c1) == LOWER(c2)) {
+    while (tolower((unsigned char)c1) == tolower((unsigned char)c2)) {
 	if (c1 == '\0')
 	    break;
 	c1 = *++s1;

--- a/ieee80211.c
+++ b/ieee80211.c
@@ -84,7 +84,7 @@ get_string(const char *val, const char *sep, u_int8_t *buf, int *lenp)
 
 	len = *lenp;
 	p = buf;
-	hexstr = (val[0] == '0' && tolower((u_char) val[1]) == 'x');
+	hexstr = (val[0] == '0' && tolower((unsigned char)val[1]) == 'x');
 	if (hexstr)
 		val += 2;
 	for (;;) {
@@ -95,8 +95,8 @@ get_string(const char *val, const char *sep, u_int8_t *buf, int *lenp)
 			break;
 		}
 		if (hexstr) {
-			if (!isxdigit((u_char) val[0]) ||
-			    !isxdigit((u_char) val[1])) {
+			if (!isxdigit((unsigned char)val[0]) ||
+			    !isxdigit((unsigned char)val[1])) {
 				printf("%% get_string: bad hexadecimal digits\n");
 				return NULL;
 			}
@@ -109,9 +109,9 @@ get_string(const char *val, const char *sep, u_int8_t *buf, int *lenp)
 			return NULL;
 		}
 		if (hexstr) {
-#define tohex(x)        (isdigit(x) ? (x) - '0' : tolower(x) - 'a' + 10)
-			*p++ = (tohex((u_char) val[0]) << 4) |
-				tohex((u_char) val[1]);
+#define tohex(x)        (isdigit((unsigned char)(x)) ? (x) - '0' : \
+			    tolower((unsigned char)(x)) - 'a' + 10)
+			*p++ = (tohex(val[0]) << 4) | tohex(val[1]);
 #undef tohex
 			val += 2;
 		} else {
@@ -139,12 +139,14 @@ make_string(char *str, int str_len, const u_int8_t *buf, int buf_len)
 	str_len--;
 	i = 0;
 	hasspc = 0;
-	if (buf_len < 2 || buf[0] != '0' || tolower(buf[1]) != 'x') {
+	if (buf_len < 2 || buf[0] != '0' ||
+	    tolower((unsigned char)buf[1]) != 'x') {
 		for (; i < buf_len; i++) {
 			/* Only print 7-bit ASCII keys */
-			if (buf[i] & 0x80 || !isprint(buf[i]))
+			if (buf[i] & 0x80 ||
+			    !isprint((unsigned char)buf[i]))
 				break;
-			if (isspace(buf[i]))
+			if (isspace((unsigned char)buf[i]))
 				hasspc++;
 		}
 	}
@@ -210,7 +212,7 @@ intnwkey(char *ifname, int ifs, int argc, char **argv)
 		goto set_nwkey;
 	} else {
 set_nwkey:
-		if (isdigit(val[0]) && val[1] == ':') {
+		if (isdigit((unsigned char)val[0]) && val[1] == ':') {
 			/* specifying a full set of four keys */
 			nwkey.i_defkid = val[0] - '0';
 			val += 2;
@@ -380,15 +382,14 @@ get_nwinfo(char *ifname, char *str, int str_len, int type)
 				}
 				/* check extra ambiguity with keywords */
 				if (!nwkey_verbose) {
-					if (nwkey.i_key[0].i_keylen >= 2 &&
-					    isdigit(nwkey.i_key[0].i_keydat[0])
-					    && nwkey.i_key[0].i_keydat[1] ==
-					    ':')
+					uint8_t *kdat = nwkey.i_key[0].i_keydat;
+					size_t klen = nwkey.i_key[0].i_keylen;
+					if (klen >= 2 &&
+					    isdigit((unsigned char)kdat[0]) &&
+					    kdat[1] == ':')
 						nwkey_verbose = 1;
-					else if (nwkey.i_key[0].i_keylen >= 7 &&
-						    isprefix(
-						    nwkey.i_key[0].i_keydat,
-						    "persist"))
+					else if (klen >= 7 &&
+					    isprefix(kdat, "persist"))
 						nwkey_verbose = 1;
 				}
 				if (nwkey_verbose) {

--- a/if.c
+++ b/if.c
@@ -1769,7 +1769,7 @@ intgroup(char *ifname, int ifs, int argc, char **argv)
 
 	for (i = 0; i < argc; i++) {
 		/* Validate supplied argument(s) before applying them */
-		if (isdigit(argv[i][strlen(argv[i]) - 1])) {
+		if (isdigit((unsigned char)argv[i][strlen(argv[i]) - 1])) {
 			printf("%% Group names may not end with a digit\n");
 			return 0;
 		}


### PR DESCRIPTION
The ctype functions take int arguments, which may have the value of any char and additionally EOF, like the return value of getc(3). On architectures like x86 where char is signed by default, passing a char to an int parameter will sign-extend the value. In particular, a char with value 0xff will turn into 0xffffffff, which is -1, which is typically the value of EOF. Confusion results between 0xff and EOF.

To prevent this problem cast arguments to (unsigned char) in all calls to isspace(), tolower(), isxdigit(), isdigit(), and isprint(), as done all over the OpenBSD base source tree nowadays. There are a few cases where the argument is already unsigned but those re now also cast for cosmetic reasons. There were no cases where the argument was already of type int which would make casting unnecessary.

Also: 

Replace some use of non-standard u_char with unsigned char, in order to make ctype-usage bulk-reviews easier in combination with 'grep'.

Remove pointless LOWER() macro which just re-implements an isupper() check which tolower() is already doing internally.