### PR TITLE
add support for the staticarp interface flag

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -534,6 +534,7 @@ struct intlist Intlist[] = {
 	{ "metric",	"Routing metric",			CMPL0 0, 0, intmetric },
 	{ "link",	"Link level options",			CMPL0 0, 0, intlink },
 	{ "arp",	"Address Resolution Protocol",		CMPL0 0, 0, intflags },
+	{ "staticarp",	"Always use static ARP to find other hosts",CMPL0 0, 0, intflags },
 	{ "lladdr",	"Link Level (MAC) Address",		CMPL0 0, 0, intlladdr },
 	{ "nwid",	"802.11 network ID",			CMPL0 0, 0, intnwid },
 	{ "nwkey",	"802.11 network key",			CMPL0 0, 0, intnwkey },

--- a/conf.c
+++ b/conf.c
@@ -798,8 +798,14 @@ void conf_ifflags(FILE *output, int flags, char *ifname, int ippntd, u_char ift)
 			fprintf(output, "2");
 		fprintf(output, "\n");
 	}
-	if (flags & IFF_NOARP && ift != IFT_WIREGUARD)
-		fprintf(output, " no arp\n");
+
+	/* wg(4) sets IFF_NOARP by default and this should not be changed. */
+	if (ift != IFT_WIREGUARD) {
+		if (flags & IFF_NOARP)
+			fprintf(output, " no arp\n");
+		if (flags & IFF_STATICARP)
+			fprintf(output, " staticarp\n");
+	}
 
 	if (isprefix("pppoe", ifname)) {		/* XXX */
 		fprintf(output, " no shutdown\n");

--- a/externs.h
+++ b/externs.h
@@ -374,6 +374,7 @@ int parse_ipv6(char *, struct in6_addr *);
 #define SLAACD_SOCK	"/dev/slaacd.sock"
 #define IFDATA_MTU 1		/* request for if_data.ifi_mtu */
 #define IFDATA_BAUDRATE 2	/* request for if_data.ifi_baudrate */
+#define IFDATA_IFTYPE 3		/* request for if_data.ifi_type */
 #define MBPS(bps) (bps / 1000 / 1000)
 #define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
 #define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))

--- a/nsh.8
+++ b/nsh.8
@@ -2232,6 +2232,7 @@ nsh(interface-em0)/?
   metric           Routing metric
   link             Link level options
   arp              Address Resolution Protocol
+  staticarp        Always use static ARP to find other hosts
   lladdr           Link Level (MAC) Address
   nwid             802.11 network ID
   nwkey            802.11 network key
@@ -2474,6 +2475,34 @@ Enable or disable Address Resolution Protocol ARP on the interface.
 nsh(interface-fxp0)/arp
 nsh(interface-fxp0)/no arp
 .Ed
+.Pp
+.Op no
+.Ic staticarp
+.Pp
+Always use static ARP entries to find other hosts reachable via the interface.
+(Disabled by default.)
+.Bd -literal -offset indent
+nsh(interface-fxp0)/staticarp
+nsh(interface-fxp0)/no staticarp
+.Ed
+.Pp
+Only hosts with entries in the static ARP table will be reachable via
+the interface.
+Static ARP entries can be configured using the
+.Cm arp
+command in the global context (not the
+.Cm arp
+command in the interface context).
+.Pp
+When
+.Cm staticarp
+is enabled no ARP requests will be sent out on the interface, while
+responses to incoming ARP requests for the interface's own addresses
+will still be sent.
+If ARP was previously disabled on the interface with the
+.Cm no arp
+command then ARP will be automatically re-enabled to allow outgoing
+ARP responses.
 .Pp
 .Op no
 .Ic lladdr


### PR DESCRIPTION
Add support for static ARP mode, where no ARP requests are transmitted on an interface while responses to incoming ARP requests for the interface's own addresses will still be sent.

While here, ensure that the NOARP flag set on wg interfaces cannot be cleared. Testing shows clearing the flag is possible which could result in problems.