### PR TITLE
Proxyarp

### DIFF
--- a/arp.c
+++ b/arp.c
@@ -535,7 +535,7 @@ ether_str(struct sockaddr_dl *sdl)
 
 /* -1 error */
 int
-rtmsg_arp(cmd, flags, doing_proxy, export_only)
+rtmsg_arp(int cmd, int flags, int doing_proxy, int export_only)
 {
 	static int seq;
 	struct rt_msghdr *rtm;

--- a/arp.c
+++ b/arp.c
@@ -447,9 +447,15 @@ conf_arp_entry(FILE *output, char *delim, struct sockaddr_dl *sdl,
 
 	host = inet_ntoa(sin->sin_addr);
 
-	if (!(rtm->rtm_flags & (RTF_PERMANENT_ARP|RTF_LOCAL|RTF_BROADCAST)) &&
-	    (rtm->rtm_rmx.rmx_expire == 0))
-		fprintf(output, "%s%s %s\n", delim, host, ether_str(sdl));
+	if ((rtm->rtm_flags & RTF_LOCAL) || rtm->rtm_rmx.rmx_expire != 0)
+		return;
+
+	fprintf(output, "%s%s %s", delim, host, ether_str(sdl));
+	if (rtm->rtm_flags & RTF_PERMANENT_ARP)
+		fputs(" permanent", output);
+	if (rtm->rtm_flags & RTF_ANNOUNCE)
+		fputs(" pub", output);
+	fputs("\n", output);
 }
 
 /*

--- a/commands.c
+++ b/commands.c
@@ -987,9 +987,6 @@ Command cmdtab[] = {
 	{ "rtable",	rtablehelp,	CMPL0 0, 0, rtable,	0, 1, 2 },
 	{ "group",	grouphelp,	CMPL0 0, 0, group,	1, 1, 0 },
 	{ "arp",	arphelp,	CMPL0 0, 0, arpset,	1, 1, 0 },
-#ifdef notyet
-	{ "proxy-arp",	parphelp,	CMPL0 0, 0, arpset,	1, 1, 0 },
-#endif
 	{ "nameserver",	nameserverhelp,	CMPL0 0, 0, nameserverset,1, 1, 0 },
 	{ "bridge",	bridgehelp,	CMPL(i) 0, 0, interface, 1, 1, 1 },
 	{ "show",	showhelp,	CMPL(ta) (char **)showlist, sizeof(Menu), showcmd,	0, 0, 0 },


### PR DESCRIPTION
Allow adding proxy ARP entries, using the same syntax as offered by /usr/sbin/arp for now.