### PR TITLE
implement a cisco-style 'show interface status' command

### DIFF
--- a/complete.c
+++ b/complete.c
@@ -260,11 +260,11 @@ complete_ifname(char *word, int list, EditLine *el)
 	StringList *words;
 	size_t wordlen;
 	unsigned char rv;   
+	const char *status_cmd = "status";
+	struct if_nameindex *ifn_list, *ifnp;
 
 	words = sl_init();
 	wordlen = strlen(word);
-
-	struct if_nameindex *ifn_list, *ifnp;
 
 	if ((ifn_list = if_nameindex()) == NULL)
 		return 0;
@@ -275,6 +275,14 @@ complete_ifname(char *word, int list, EditLine *el)
                 if (strncmp(word, ifnp->if_name, wordlen) == 0)
                         sl_add(words, ifnp->if_name);
         }
+
+	if (wordlen <= strlen(status_cmd) &&
+	    strncmp(word, status_cmd, wordlen) == 0) {
+		char *s = strdup(status_cmd);
+		if (s == NULL)
+			err(1, "strdup");
+		sl_add(words, s);
+	}
 
         rv = complete_ambiguous(word, list, words, el);
 	if_freenameindex(ifn_list);

--- a/externs.h
+++ b/externs.h
@@ -469,6 +469,11 @@ int phys_status(int, char *, char *, char *, int, int);
 int intmedia(char *, int, int, char **);
 int intmediaopt(char *, int, int, char **);
 int conf_media_status(FILE *, int, char *);
+struct ifmediareq;
+const char *get_ifm_linkstate_str(struct ifmediareq *);
+const char *get_ifm_options_str(char *, size_t, uint64_t, uint64_t *);
+const char *get_ifm_type_str(uint64_t);
+const char *get_ifm_subtype_str(uint64_t);
 
 /* passwd.c */
 #define NSHPASSWD_TEMP "/var/run/nshpasswd"


### PR DESCRIPTION
This new command provides a concise list of all interfaces, showing a brief overview of up/down status, link layer status, and media types. It is more useful than 'show interface' when a high-level view of all available interfaces is desired.