### PR TITLE
support the VISUAL environment variable as well as EDITOR

### DIFF
--- a/ctl.c
+++ b/ctl.c
@@ -705,8 +705,10 @@ call_editor(char *name, char **args, char *z)
 	    cli_rtable);
 
 	/* acq lock, call editor, test config with cmd and args, release lock */
-	if ((editor = getenv("EDITOR")) == NULL)
-		editor = DEFAULT_EDITOR;
+	if ((editor = getenv("VISUAL")) == NULL) {
+		if ((editor = getenv("EDITOR")) == NULL)
+			editor = DEFAULT_EDITOR;
+	}
 	if ((fd = acq_lock(tmpfile)) > 0) {
 		char *argv[] = { editor, tmpfile, NULL };
 		cmdargs(editor, argv);


### PR DESCRIPTION
Check VISUAL before EDITOR because by tradition the former overrides the latter (source: the ksh(1) man page).