### PR TITLE
add a "show bridge" command

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -168,6 +168,7 @@ Menu showlist[] = {
 	{ "arp",	"ARP table",		CMPL0 0, 0, 0, 1, pr_arp },
 	{ "ndp",	"NDP table",		CMPL0 0, 0, 0, 1, pr_ndp },
 	{ "vlan",	"802.1Q/802.1ad VLANs",	CMPL0 0, 0, 0, 1, show_vlans },
+	{ "bridge",	"Ethernet bridges",	CMPL0 0, 0, 0, 1, show_bridges },
 	{ "kernel",	"Kernel statistics",	CMPL(ta) (char **)stts, sizeof(struct stt), 0, 1, pr_kernel },
 	{ "bgp",	"BGP information",	CMPL(ta) (char **)bgcs, sizeof(struct prot1), 0, 4, pr_prot1 },
 	{ "ospf",	"OSPF information",	CMPL(ta) (char **)oscs, sizeof(struct prot1), 0, 3, pr_prot1 },

--- a/externs.h
+++ b/externs.h
@@ -453,6 +453,7 @@ int flush_bridgedyn(char *);
 int flush_bridgeall(char *);
 int flush_bridgerule(char *, char*);
 int brprotect(char *, int, int, char **);
+int show_bridges(int, char **);
 
 /* tunnel.c */
 int inttunnel(char *, int, int, char **);


### PR DESCRIPTION
This command provides a quick overview of bridges in the system and show their member interfaces.

Long lists of member interfaces wrap at 80 columns. For example:

nsh/show bridge
% Bridge    Status  Member Interfaces
  veb0      up      vport0 em1 athn0 tap0 tap1 tap80 tap81 tap82 tap83 tap84
                    tap85 tap86 tap87 tap88 tap89 tap90 tap91 tap92 tap93 tap94
                    tap95 tap96 tap97 tap98 tap99 
  bridge0   down    tap72 tap71 tap70
nsh/

I considered displaying the bridge interface's description as well. However, keeping the display visually aligned would be difficult. The list of members already has an arbitrary length, and so does the description. The description can be viewed by other means so this is not a big loss.