### PR TITLE
get rid of cc compiler warning

### DIFF
--- a/nwrapper.c
+++ b/nwrapper.c
@@ -17,4 +17,6 @@ int
 main()
 {
  execl("/usr/bin/sudo","/usr/bin/sudo","/bin/nsh", (char *)NULL);
+ return 0;
+ 
 }

--- a/nwrapper.c
+++ b/nwrapper.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+int
 main()
 {
  execl("/usr/bin/sudo","/usr/bin/sudo","/bin/nsh", (char *)NULL);


### PR DESCRIPTION
cc nwrapper.c                                                            nwrapper.c:16:1: warning: type specifier missing, defaults to 'int' [-Wimplicit-int] main()
^