### PR TITLE
update nwrapper to use doas rather than sudo and correct paths

### DIFF
--- a/nsh.8
+++ b/nsh.8
@@ -4111,7 +4111,8 @@ The doas configurations outlined here are not
 security measures.
 They allow an administrator to grant a non root
 user the ability to run
-.Nm with all the privileges of the
+.Nm
+with all the privileges of the
 .Ox
 root user.
 The design of

--- a/nsh.8
+++ b/nsh.8
@@ -4022,44 +4022,88 @@ see the following man pages for information
 .Pp
 !man pfctl
 !man pf.conf
-.Sh Section 7 > Adding system users to
+.Sh Section 7 Adding system users to
 .Nm
-.
+on
+.Ox
 .Pp
 .Ox
-has facilities for a user to be able to login directly to nsh without
-having access to a typical bourne or C shell.
+has facilities for a user to be able to login directly to
+.Nm
+without having access to a typical bourne or C shell.
+Using doas (a tool similar to sudo in other POSIX systems)
+one can setup doas to allow the user to launch nsh as root.
+there are 3 options for doing this.
 .Pp
-Configure the user so they can run /bin/nsh from sudo.
-You must do this in /etc/sudoers, like this:
-.Bd -literal -offset indent
-nshuser		ALL=NOPASSWD:/bin/nsh
-.Ed
-(replace 'nshuser' with the actual user name)
+Option1 - least restrictive interactive and non-interactive
+.Nm
 .Pp
-Another way to configure sudoers is to allow all users that are members
-of a certain group to run NSH through sudo, like this:
-.Bd -literal -offset indent
-%nshgroup	ALL=NOPASSWD:/bin/nsh
+To allow a user to run nsh interactively or non interactively
+as root when logged in or logging in.
+Configuring /etc/doas.conf with the line starting with 'permit'
+to allow the full path to the nsh binary without any other
+restrictions.
+e.g. Configure the user 'stacy' so they can run
+.Bd -literal
+/usr/local/bin/nsh as root
+or
+/usr/local/bin/nsh -c /some/path/to/scriptedconfig.nshrc
 .Ed
-(replace 'nshgroup' with the actual group name)
+.Bd -literal -offset indent
+permit nopass stacy as root cmd /usr/local/bin/nsh
+.Ed
+.Pp
+Option2 - allow interactive
+.Nm
+use only.
+.Pp
+Configuring /etc/doas.conf with the line starting with 'permit'
+to allow the full path to the nsh binary and specify empty args
+to enforce nsh be run without any arguments.
+.Bd -literal -offset indent
+permit nopass stacy as root cmd /usr/local/bin/nsh args
+.Ed
+.Pp
+Option3 - allow non-interactive
+.Nm
+use only.
+.Pp
+To allow a restricted user run a specifc configuration script only.
+Configuring /etc/doas.conf with the line starting with 'permit'
+to allow the full path to the nsh binary and specify args
+to enforce nsh be run only with those specific arguments.
+E.g.to allow a backupuser pull the running config only.
+.Bd -literal -offset indent
+permit nopass backupuser as root cmd /usr/local/bin/nsh args -c /home/backupuser/showrunconfig.nshrc
+.Ed
+.Pp
+The /home/backup/showrunconfig.nshrc would look like this
+.Bd -literal -offset indent
+enable
+show run
+quit
+.Ed
+.Pp
+A more standards RBAC based approach would be to create a group
+on the system for users with the role of manging the system via nsh.
+Then simply allow all users that are members of a group to run
+.Nm
+using /etc/doas.conf and referring to the groupname rather than just
+a single username.
 .Pp
 Compile nwrapper (in the nsh distribution):
 .Bd -literal -offset indent
-cc -static -o nwrapper nwrapper.c
+cc -o nwrapper nwrapper.c
 .Ed
 Move nwrapper to a permanent location:
 .Bd -literal -offset indent
-mv nwrapper /bin/nwrapper
+mv nwrapper /usr/local/bin/nwrapper
 .Ed
 Change the user's shell to nwrapper:
 .Bd -literal -offset indent
-usermod -s /bin/nwrapper nshuser
+usermod -s /usr/local/bin/nwrapper nshuser
 .Ed
 (replace 'nshuser' with the actual user name)
-.Pp
-Do NOT add nwrapper (or nsh) to /etc/shells.
-They should not be entered here.
 .Sh Common interface types
 Packet Filter Logging: This interface is used to pass traffic logged by
 the firewall to software which can record it.

--- a/nsh.8
+++ b/nsh.8
@@ -4133,9 +4133,10 @@ grants
 user access with the same security considerations
 of granting a user root access to the system.
 I.e. the user can use
-.Nm running as root (facilitated by doas and nwrapper)
-to carry out other shell scripts either interactively or in a
-nshrc configuration file.
+.Nm
+running as root (facilitated by doas and nwrapper)
+to carry out other shell scripts either interactively or
+in a nshrc configuration file.
 It gives a user the ability to configure basic system
 parameters and to run editors and other commands as root.
 Therefore access to

--- a/nsh.8
+++ b/nsh.8
@@ -4107,11 +4107,40 @@ usermod -s /usr/local/bin/nwrapper nshuser
 .Pp
 *NB Security Warning!!!
 .Pp
-The doas configs here are not completely iron clad!
-the user can use doas running as root to carry out other
-shell scripts launched by nsh either interactively or in a
-nshrc config file.
-This obvious privilege escalation path can be restricted.
+The doas configurations outlined here are not
+security measures.
+They allow an administrator to grant a non root
+user the ability to run
+.Nm with all the privileges of the
+.Ox
+root user.
+The design of
+.Ox
+requires root privileges to change many aspects of
+the systems network stack. 
+The nwrwapper binary is a binary that hardcodes the
+doas request to launch
+.Nm
+on
+.Ox
+as root.
+.Nm
+currently does not have security countermeasure
+features against malicious users.
+It is therefore essential that the administrator only
+grants
+.Nm
+user access with the same security considerations
+of granting a user root access to the system.
+I.e. the user can use
+.Nm running as root (facilitated by doas and nwrapper)
+to carry out other shell scripts either interactively or in a
+nshrc configuration file.
+It gives a user the ability to configure basic system
+parameters and to run editors and other commands as root.
+Therefore access to
+.Nm
+must be restricted to trusted users only.
 .Sh Common interface types
 Packet Filter Logging: This interface is used to pass traffic logged by
 the firewall to software which can record it.

--- a/nsh.8
+++ b/nsh.8
@@ -4104,6 +4104,14 @@ Change the user's shell to nwrapper:
 usermod -s /usr/local/bin/nwrapper nshuser
 .Ed
 (replace 'nshuser' with the actual user name)
+.Pp
+*NB Security Warning!!!
+.Pp
+The doas configs here are not completely iron clad!
+the user can use doas running as root to carry out other
+shell scripts launched by nsh either interactively or in a
+nshrc config file.
+This obvious privilege escalation path can be restricted.
 .Sh Common interface types
 Packet Filter Logging: This interface is used to pass traffic logged by
 the firewall to software which can record it.

--- a/nwrapper.c
+++ b/nwrapper.c
@@ -4,10 +4,15 @@
  */
 
 /*
- * for 'stacy' to login to this shell and launch nsh, this
- * is what you would put in /etc/sudoers:
+ * E.g. to allow the user 'stacy' to login to this shell and launch 
+ * nsh interactive mode only put the following line in /etc/doas.conf:
+ * 
+ * permit nopass stacy as root cmd /usr/local/bin/nsh args
  *
- * stacy		ALL=NOPASSWD:/bin/nsh
+ * to allow a restricted user e.g. a backup user 'backupuser' 
+ * run nsh in non interactive mode and run a specific nshrc script
+ * put the following line in /etc/doas.conf 
+ * permit nopass backupuser as root cmd /usr/local/bin/nsh args -c /home/backupuser/showrun.nshrc  
  */
 
 #include <stdio.h>
@@ -16,7 +21,7 @@
 int
 main()
 {
- execl("/usr/bin/sudo","/usr/bin/sudo","/bin/nsh", (char *)NULL);
+ execl("/usr/bin/doas","/usr/bin/doas","/usr/local/bin/nsh", (char *)NULL);
  return 0;
  
 }


### PR DESCRIPTION
update nwrapper to use doas rather than sudo and correct paths update the comments to reflect /etc/doas.conf syntax rather than sudo update the manual to reflect doas approach and outline with more examples 3 levels of restrictions that can be placed on nsh using /etc/doas.conf