### PR TITLE
add the "ipcp" command which configures IPCP on pppoe interfaces

### DIFF
--- a/externs.h
+++ b/externs.h
@@ -50,7 +50,13 @@ int nopt(int, char **, struct nopts *);
 
 /* ppp.c */
 int intsppp(char *, int, int, char **);
+void pppoe_ipcp(char *, int, int);
 int intpppoe(char *, int, int, char **);
+int is_pppoe(char *, int);
+#define NSH_PPPOE_IPADDR_IPCP 1
+#define NSH_PPPOE_IPADDR_STATIC 2
+int pppoe_get_ipaddrmode(char *);
+void pppoe_conf_default_route(FILE *, char *, char *, char *, char *, char *);
 void conf_pppoe(FILE *, int, char *);
 void conf_sppp(FILE *, int, char *);
 
@@ -398,6 +404,7 @@ int set_ifxflags(char *, int, int);
 u_int32_t in4_netaddr(u_int32_t, u_int32_t);
 u_int32_t in4_brdaddr(u_int32_t, u_int32_t);
 int intip(char *, int, int, char **);
+int intipcp(char *, int, int, char **);
 int intmtu(char *, int, int, char **);
 int intkeepalive(char *, int, int, char **);
 int intrdomain(char *, int, int, char **);

--- a/main.c
+++ b/main.c
@@ -107,6 +107,8 @@ main(int argc, char *argv[])
 		printf("%% database peerkey creation failed\n");
 	if (db_create_table_nameservers() < 0)
 		printf("%% database nameservers creation failed\n");
+	if (db_create_table_flag_x("pppoeipaddrmode") < 0)
+		printf("%% database pppoeipaddrmode creation failed\n");
 
 	if (iflag) {
 		/*


### PR DESCRIPTION
The ipcp command enables IP address negotiation on pppoe interfaces, and disables such negotiation when prefixed with "no'.

Provide aliases to run the same command if users type "ip ipcp" or try to use "autoconf4" in the pppoe interface context.

IPv6 is not handled yet, this will be done later.