### PR TITLE
tab-completion fixes

### DIFF
--- a/complete.c
+++ b/complete.c
@@ -310,15 +310,21 @@ complete(EditLine *el, int ch, char **table, size_t stlen, char *arg)
 		return (CC_ERROR);
 	(void)memcpy(line, lf->buffer, len);
 	line[len] = '\0';
+	if (strlen(word) > len) /* user has erased part of previous line */
+		word[len] = '\0';
 	cursor_pos = line + (lf->cursor - lf->buffer);
 	lastc_argc = cursor_argc;	/* remember last cursor pos */
 	lastc_argo = cursor_argo;
 	makeargv();			/* build argc/argv of current line */
 
-	if (margc == 0 || cursor_argo >= sizeof(word))
+	if (cursor_argo >= sizeof(word))
 		return (CC_ERROR);
 
-	dolist = 0;
+	if (margc == 0) {
+		dolist = 1;
+		return (complete_command(word, dolist, el, table, stlen));
+	} else
+		dolist = 0;
 
 	/* if cursor and word is same, list alternatives */
 	if (lastc_argc == cursor_argc && lastc_argo == cursor_argo


### PR DESCRIPTION
Make tab-completion work at the empty command prompt by resolving empty input to completions for all existing commands.

Also, fix the list of completions displayed after the user erases part of the previous line of input. For instance, the following sequence would result in possible completions for 'e' being displayed rather than the possible completions for all commands:

   nsh.my.domain/eTAB
   editing eigrp  enable
   nsh.my.domain/BACKSPACE  (delete 'e')
   nsh.my.domain/TAB
   editing eigrp  enable    (should display all available commands instead)