### PR TITLE
rename interface context "ip" command to "address"

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -522,10 +522,11 @@ flush_help(void)
 
 struct intlist Intlist[] = {
 /* Interface mode commands */
-	{ "ip",		"IP address and other parameters",	CMPL0 0, 0, intip },
-	{ "alias",	"Additional IP addresses and other parameters", CMPL0 0, 0, intip },
+	{ "address",	"Static IPv4/IPv6 address",		CMPL0 0, 0, intip },
+	{ "ip",		NULL, /* backwards compatibilty */	CMPL0 0, 0, intip },
+	{ "alias",	"Additional static IPv4/IPv6 addresses",CMPL0 0, 0, intip },
 #ifdef IFXF_AUTOCONF4		/* 6.6+ */
-	{ "autoconf4",  "IPv4 Autoconfigurable address",	CMPL0 0, 0, intxflags },
+	{ "autoconf4",  "IPv4 Autoconfigurable address (DHCP)",	CMPL0 0, 0, intxflags },
 #endif
 	{ "description", "Interface description",		CMPL0 0, 0, intdesc },
 	{ "group",	"Interface group",			CMPL0 0, 0, intgroup },

--- a/conf.c
+++ b/conf.c
@@ -715,7 +715,7 @@ int conf_ifaddr_dhcp(FILE *output, char *ifname, int ifs, int flags)
 	    LEASEPREFIX, ifname);
 	if (dhcpleased_controls_interface(ifname, ifs) ||
 	    (dhcpif = fopen(leasefile, "r")) != NULL) {
-		fprintf(output, " ip dhcp\n");
+		fprintf(output, " autoconf4\n");
 		if (dhcpif)
 			fclose(dhcpif);
 		/* print all non-autoconf ipv6 addresses */
@@ -811,7 +811,7 @@ void conf_ifflags(FILE *output, int flags, char *ifname, int ippntd, u_char ift)
 		fprintf(output, " no shutdown\n");
 	} else {
 		/*
-		 * ip X/Y turns the interface up (just like 'no shutdown')
+		 * address X/Y turns the interface up (just like 'no shutdown')
 		 * ...but if we never had an ip address set and the interface
 		 * is up, we need to save this state explicitly.
 		 */
@@ -1200,7 +1200,7 @@ int conf_ifaddrs(FILE *output, char *ifname, int flags, int af)
 			sinmask = (struct sockaddr_in *)ifa->ifa_netmask;
 			if (flags & IFF_POINTOPOINT) {
 				sindest = (struct sockaddr_in *)ifa->ifa_dstaddr;
-				fprintf(output, " ip %s",
+				fprintf(output, " address %s",
 				    routename4(sin->sin_addr.s_addr));
 				if (ntohl(sindest->sin_addr.s_addr) !=
 				    INADDR_ANY)
@@ -1208,7 +1208,7 @@ int conf_ifaddrs(FILE *output, char *ifname, int flags, int af)
 					    inet_ntoa(sindest->sin_addr));
 			} else if (flags & IFF_BROADCAST) {
 				sindest = (struct sockaddr_in *)ifa->ifa_broadaddr;
-				fprintf(output, " ip %s",
+				fprintf(output, " address %s",
 				    netname4(sin->sin_addr.s_addr, sinmask));
 				/*
 				 * don't save a broadcast address that would be
@@ -1222,7 +1222,7 @@ int conf_ifaddrs(FILE *output, char *ifname, int flags, int af)
 					fprintf(output, " %s",
 					    inet_ntoa(sindest->sin_addr));
 			} else {
-				fprintf(output, " ip %s",
+				fprintf(output, " address %s",
 				    netname4(sin->sin_addr.s_addr, sinmask));
 			}
 			ippntd = 1;
@@ -1259,12 +1259,12 @@ int conf_ifaddrs(FILE *output, char *ifname, int flags, int af)
 			}
 
 			if (flags & IFF_POINTOPOINT) {
-				fprintf(output, " ip %s", routename6(sin6));
+				fprintf(output, " address %s", routename6(sin6));
 				sin6dest = (struct sockaddr_in6 *)ifa->ifa_dstaddr;
 				in6_fillscopeid(sin6dest);
 				fprintf(output, " %s", routename6(sin6dest));
 			} else {
-				fprintf(output, " ip %s",
+				fprintf(output, " address %s",
 				    netname6(sin6, sin6mask));
 			}
 			ippntd = 1;

--- a/if.c
+++ b/if.c
@@ -967,10 +967,12 @@ intip(char *ifname, int ifs, int argc, char **argv)
 		set = 1;
 
 	/*
-	 * We use this function for ip and alias setup since they are
+	 * We use this function for address and alias setup since they are
 	 * the same thing.
 	 */
-	if (isprefix(argv[0], "alias")) {
+	if (isprefix(argv[0], "address")) {
+		cmdname = "address";
+	} else if (isprefix(argv[0], "alias")) {
 		cmdname = "alias";
 	} else if (isprefix(argv[0], "ip")) {
 		cmdname = "ip";
@@ -1005,12 +1007,13 @@ intip(char *ifname, int ifs, int argc, char **argv)
 	}
 
 	/* ignore 'address' keyword, don't print error */
-	if (isprefix(argv[0], "address")) {
+	if (strcmp(cmdname, "ip") == 0 && isprefix(argv[0], "address")) {
 		argc--;
 		argv++;
 	}
 
-	if (isprefix(argv[0], "dhcp")) {
+	/* Support deprecated "ip dhcp" command for reading old configs. */
+	if (strcmp(cmdname, "ip") == 0 && isprefix(argv[0], "dhcp")) {
 		if (dhcpleased_is_running()) {
 			/*
 			 * dhclient(8) has gone away as of OpenBSD 7.2+.

--- a/nsh.8
+++ b/nsh.8
@@ -393,16 +393,15 @@ routing domain
 e.g. Create a new routing table rdomain 3 create a loopback for rdomain 3.
 .Bd -literal -offset indent
 nsh(p)/interface lo3
-nsh(interface-lo3)/rt
 nsh(interface-lo3)/rdomain 3
-nsh(interface-lo3)/ip 127.0.0.1/8
+nsh(interface-lo3)/address 127.0.0.1/8
 .Ed
 .It
 configure a physical interface
 .Bd -literal -offset indent
 nsh(p)/interface em0
 nsh(interface-em0)/rdomain 3
-nsh(interface-em0)/ip 10.255.0.10/24
+nsh(interface-em0)/address 10.255.0.10/24
 .Ed
 .It
 Once the rdomain has been initialized (by creating a loopback inside the
@@ -2768,12 +2767,13 @@ Displays the help menu and available ip command options.
 .Bd -literal -offset indent
 nsh(p)/ip ?
 .Ed
+.Pp
 .Tg interface
 .Op no
 .Ic interface
-.Op  ip | alias | description | group | rdomain | rtlabel | priority\
- | llpriority | mtu | metric | link | arp | lladdr | nwid | nwkey\
- | powersave | txpower | bssid | media | mediaopt | auth | peer\
+.Op  address | alias | autoconf4 | description | group | rdomain | \
+ | rtlabel | priority| llpriority | mtu | metric | link | arp | lladdr | nwid \
+ | nwkey | powersave | txpower | bssid | media | mediaopt | auth | peer\
  | pppoe | tunnel | tunneldomain | txprio | rxprio | vnetid\
  | vnetflowid | parent | patch | keepalive | mplslabel | pwe\
  | syncdev | syncpeer | maxupd | vhid | advbase | advskew | carppass\
@@ -2789,8 +2789,9 @@ nsh(interface-em0)/?
 % Type 'exit' at a prompt to leave interface configuration mode.
 % Interface configuration commands are:
 
-  ip               IP address and other parameters
-  alias            Additional IP addresses and other parameters
+  address          Static IPv4/IPv6 address
+  alias            Additional static IPv4/IPv6 addresses
+  autoconf4        IPv4 Autoconfigurable address (DHCP)
   description      Interface description
   group            Interface group
   rdomain          Interface routing domain
@@ -2856,39 +2857,36 @@ nsh(interface-em0)/?
 .Ed
 .Pp
 .Op no
-.Ic ip
-.Op dhcp
-.Ar | address/prefix-length | address/netmask
+.Ic address
+.Ar address/prefix-length | address/netmask
 .Pp
-Adds or removes the main IP address and other related parameters on the
-interface.
+Adds or removes static IP addresses on the interface.
 IPv4 addresses can be configured with CIDR bitlength, or classic netmask.
 The IPv6 address may only be configured with a bitlength.
 .Bd -literal -offset indent
-nsh(interface-lo0)/ip ::1/128
+nsh(interface-lo0)/address ::1/128
 .Ed
 or
 .Bd -literal -offset indent
-nsh(interface-fxp0)/ip 192.168.100.1/24
+nsh(interface-fxp0)/address 192.168.100.1/24
 .Ed
 or
 .Bd -literal -offset indent
-nsh(interface-fxp0)/ip 192.168.100.1/255.255.255.0
+nsh(interface-fxp0)/address 192.168.100.1/255.255.255.0
 .Ed
 .Pp
 .Op no
 .Ic alias
 .Ar address/prefix-length | address/netmask
 .Pp
-Deprecated, adds or removes additional IP address and other related
-parameters on the interface.
-IPv4 addresses can be configured with CIDR bitlength, or classic netmask.
-The IP address may only be configured with a bitlength.
+Deprecated and equivalent to the
+.Cm address
+command.
 .Pp
 .Op no
-.Ic ip dhcp
+.Ic autoconf4
 .Pp
-Enables or disables dhclient on a given (broadcast and layer2 capable)
+Enables or disables DHCP on a given (broadcast and layer2 capable)
 interface.
 .Pp
 DHCP client notes:
@@ -2897,25 +2895,6 @@ There is currently no way to control default gateway if DHCP client is used
 on multiple interfaces.
 The first DHCP client interface to succeed in obtaining a lease sets the
 default gateway.
-.Pp
-If /var/db is kept across reboots, (such as in a configuration where
-.Nm
-is used on a hard disk) /var/db/dhclient.leasees.$if files may exist where
-not desired.
-The presence of /var/db/dhclient.leases.$if (where $if is the interface name)
-triggers DHCP mode to be turned on in saved
-.Nm
-configurations (write) and in displayed
-.Nm
-configurations (show running-config).
-If you are using
-.Nm
-on a system where /var is kept persistently, look at the running
-configuration and execute 'no ip dhcp' for insterfaces on which you do not
-intend to use DHCP.
-.Bd -literal -offset indent
-nsh(interface-fxp0)/ip dhcp
-.Ed
 .Pp
 .Op no
 .Ic description
@@ -4335,7 +4314,7 @@ nsh(interface-vlan0)/vnetid 4
 
 nsh(interface-vlan0)/parent fxp3
 
-nsh(interface-vlan0)/ip 192.168.44.1/24
+nsh(interface-vlan0)/address 192.168.44.1/24
 .Ed
 .Ss Svlan
 This interface type allows virtual LANs to be setup over an Ethernet


### PR DESCRIPTION
There is already a different "ip" command in the global context which can make things confusing.

Going forward, only allow this command to be used for setting static IP addresses. There are already other commands for auto-configuration of addresses, such as "autoconf4".