### PR TITLE
remove pointless error message displayed by 'show sadb'

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -1320,10 +1320,8 @@ conf_routes(FILE *output, char *delim, int af, int flags, int tableid)
 		return(1);
 	}
 	rtdump = getrtdump(0, flags, tableid);
-	if (rtdump == NULL) {
-		printf("%% conf_routes: getrtdump failure\n");
+	if (rtdump == NULL)
 		return(1);
-	}
 
 	/* walk through routing table */
 	for (next = rtdump->buf; next < rtdump->lim; next += rtm->rtm_msglen) {

--- a/show.c
+++ b/show.c
@@ -128,10 +128,8 @@ p_rttables(int af, u_int tableid, int flags)
 	struct rtdump *rtdump;
 
 	rtdump = getrtdump(af, flags, tableid);
-	if (rtdump == NULL) {
-		printf("%% p_rttables: getrtdump failure\n");
+	if (rtdump == NULL)
 		return;
-	}
 
 	for (next = rtdump->buf; next < rtdump->lim; next += rtm->rtm_msglen) {
 		rtm = (struct rt_msghdr *)next;


### PR DESCRIPTION
Callers of getrtdump() do not need to print anything on failure because getrtdump() already prints important errors internally and also accounts for the ENOENT case which is harmless and means "no data available".

Found by Tom Smyth. Fixes issue #60