### PR TITLE
add tab-completion to "inet" and "inet6" commands and revive "ip"

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -525,9 +525,9 @@ flush_help(void)
 
 struct intlist Intlist[] = {
 /* Interface mode commands */
-	{ "inet",	"IPv4/IPv6 addresses",			CMPL0 0, 0, intip },
-	{ "ip",		NULL, /* backwards compatibilty */	CMPL0 0, 0, intip },
-	{ "alias",	NULL, /* backwards compatibilty */	CMPL0 0, 0, intip },
+	{ "inet",	"IPv4/IPv6 addresses",			CMPL(h) intiphelp, sizeof(char *), intip },
+	{ "ip",		"Alias for \"inet\" command",		CMPL(h) intiphelp, sizeof(char *), intip },
+	{ "alias",	NULL, /* backwards compatibilty */	CMPL(h) intiphelp, sizeof(char *), intip },
 #ifdef IFXF_AUTOCONF4		/* 6.6+ */
 	{ "autoconf4",  "IPv4 Autoconfigurable address (DHCP)",	CMPL0 0, 0, intxflags },
 #endif
@@ -587,7 +587,7 @@ struct intlist Intlist[] = {
 	{ "dhcrelay",	"DHCP Relay Agent",			CMPL0 0, 0, intdhcrelay },
 	{ "wol",	"Wake On LAN",				CMPL0 0, 0, intxflags },
 	{ "mpls",	"MPLS",					CMPL0 0, 0, intxflags },
-	{ "inet6",	"IPv6 addresses",			CMPL0 0, 0, intip },
+	{ "inet6",	"IPv6 addresses",			CMPL(h) intip6help, sizeof(char *), intip },
 	{ "autoconf6",  "IPv6 Autoconfigurable address",	CMPL0 0, 0, intxflags },
 #ifdef IFXF_INET6_NOPRIVACY	/* pre-6.9 */
 	{ "autoconfprivacy", "Privacy addresses for IPv6 autoconf", CMPL0 0, 0, intxflags },

--- a/externs.h
+++ b/externs.h
@@ -402,6 +402,8 @@ int get_ifxflags(char *, int);
 int set_ifxflags(char *, int, int);
 u_int32_t in4_netaddr(u_int32_t, u_int32_t);
 u_int32_t in4_brdaddr(u_int32_t, u_int32_t);
+extern char *intiphelp[];
+extern char *intip6help[];
 int intip(char *, int, int, char **);
 int intipcp(char *, int, int, char **);
 int intmtu(char *, int, int, char **);

--- a/if.c
+++ b/if.c
@@ -948,6 +948,21 @@ slaacd_is_running(void)
 	return check_daemon_control_socket(SLAACD_SOCK);
 }
 
+char *intiphelp[] = {
+	"<address>/<prefixlen>",
+	"<address>/<netmask>",
+	"autoconf",
+	"dhcp",
+	NULL
+};
+
+char *intip6help[] = {
+	"<address>/<prefixlen>",
+	"autoconf",
+	NULL
+};
+
+
 void
 intipusage(const char *cmdname, const char *msg)
 {
@@ -955,14 +970,8 @@ intipusage(const char *cmdname, const char *msg)
 	    msg ? "[" : "", msg ? msg : "", msg ? "]" : "");
 	printf("%% %s <address>/<netmask> %s%s%s\n", cmdname,
 	    msg ? "[" : "", msg ? msg : "", msg ? "]" : "");
-	if (strcmp(cmdname, "inet") == 0 ||
-	    strcmp(cmdname, "inet6") == 0) {
-		printf("%% no %s [<address>[/prefix-len]]\n", cmdname);
-		printf("%% no %s [<address>[/netmask]]\n", cmdname);
-	} else {
-		printf("%% no %s <address>[/prefix-len]\n", cmdname);
-		printf("%% no %s <address>[/netmask]\n", cmdname);
-	}
+	printf("%% no %s [<address>[/prefix-len]]\n", cmdname);
+	printf("%% no %s [<address>[/netmask]]\n", cmdname);
 }
 
 int
@@ -1049,13 +1058,19 @@ intip(char *ifname, int ifs, int argc, char **argv)
 	}
 
 	/* ignore 'address' keyword, don't print error */
-	if (strcmp(cmdname, "ip") == 0 && isprefix(argv[0], "address")) {
+	if (strcmp(cmdname, "ip") == 0 &&
+	    (isprefix(argv[0], "address") && !isprefix(argv[0], "autoconf"))) {
 		argc--;
 		argv++;
 	}
 
-	/* Support deprecated "ip dhcp" command for reading old configs. */
-	if (strcmp(cmdname, "ip") == 0 && isprefix(argv[0], "dhcp")) {
+	/*
+	 * Enable IPv4 DHCP with any of the following commands:
+	 *   inet dhcp, ip dhcp, inet autoconf, ip autoconf
+	 * Disable IPv4 DHCP if "no" is given for any of these commands.
+	 */
+	if (strcmp(cmdname, "inet6") != 0 &&
+	    (isprefix(argv[0], "dhcp") || isprefix(argv[0], "autoconf"))) {
 		if (dhcpleased_is_running()) {
 			/*
 			 * dhclient(8) has gone away as of OpenBSD 7.2+.
@@ -1094,6 +1109,22 @@ intip(char *ifname, int ifs, int argc, char **argv)
 			}
 			return (0);
 		}
+	}
+
+	/* Enable IPv6 SLAAC with "inet6 autoconf" and disable it with "no". */
+	if (strcmp(cmdname, "inet6") == 0 && isprefix(argv[0], "autoconf")) {
+		char *args[3] = { "no", "autoconf6", NULL };
+		char *args_set[2] = { "autoconf6", NULL };
+		char **argv_xflags;
+		int argc_xflags;
+		if (set) {
+			argv_xflags = args_set;
+			argc_xflags = nitems(args_set) - 1;
+		} else {
+			argv_xflags = args;
+			argc_xflags = nitems(args) - 1;
+		}
+		return intxflags(ifname, ifs, argc_xflags, argv_xflags);
 	}
 
 	memset(&ip, 0, sizeof(ip));

--- a/nsh.8
+++ b/nsh.8
@@ -2771,7 +2771,7 @@ nsh(p)/ip ?
 .Tg interface
 .Op no
 .Ic interface
-.Op  inet | alias | autoconf4 | description | group | rdomain | \
+.Op  inet | ip | autoconf4 | description | group | rdomain | \
  | rtlabel | priority| llpriority | mtu | metric | link | arp | lladdr | nwid \
  | nwkey | powersave | txpower | bssid | media | mediaopt | auth | peer\
  | pppoe | tunnel | tunneldomain | txprio | rxprio | vnetid\
@@ -2790,7 +2790,7 @@ nsh(interface-em0)/?
 % Interface configuration commands are:
 
   inet             IPv4/IPv6 addresses
-  alias            Additional static IPv4/IPv6 addresses
+  ip               Alias for the "inet" command
   autoconf4        IPv4 Autoconfigurable address (DHCP)
   description      Interface description
   group            Interface group
@@ -2869,11 +2869,11 @@ or
 .Bd -literal -offset indent
 nsh(interface-fxp0)/inet 192.168.100.1/255.255.255.0
 .Ed
+.Pp
 An IPv6 address may be configured with a network prefix length.
 .Bd -literal -offset indent
 nsh(interface-lo0)/inet ::1/128
 .Ed
-.Pp
 .Pp
 The command
 .Cm no inet
@@ -2883,11 +2883,41 @@ The
 command (see below) may be used to remove all IPv6 addresses.
 .Pp
 .Op no
-.Ic alias
-.Ar address/prefix-length | address/netmask
+.Ic inet
+.Cm autoconf
 .Pp
-Deprecated and equivalent to the
-.Cm address
+Equivalent to the
+.Cm autoconf4
+command.
+.Pp
+.Op no
+.Ic inet
+.Cm dhcp
+.Pp
+Equivalent to the
+.Cm autoconf4
+command.
+.Pp
+.Op no
+.Ic ip
+.Pp
+Equivalent to the
+.Cm inet
+command, for convenience.
+All parameters accepted by
+.Cm inet
+are also accepted by
+.Cm ip ,
+including
+.Cm autoconf
+and
+.Cm dhcp .
+.Pp
+.Op no
+.Ic alias
+.Pp
+Deprecated and also equivalent to the
+.Cm inet
 command.
 .Pp
 .Op no
@@ -3825,6 +3855,14 @@ nsh(p)/interface em0
 
 nsh(interface-em0)/inet6
 .Ed
+.Pp
+.Op no
+.Ic inet6
+.Cm autoconf
+.Pp
+Equivalent to the
+.Cm autoconf6
+command.
 .Pp
 .Op no
 .Ic autoconf6


### PR DESCRIPTION
Add a new tab-completion mechanism which displays usage information when some or all paramters cannot be expanded automatically. Parameters which are not arbitrary will be completed as usual. For this to work, placeholders representing arbitrary parameters, such as IP addresses, must be listed in pointy brackets in the help text. Such arbitrary parameters will never be tab-completed. Non-arbitrary parameters must be listed without brackets and will be tab-completed if matched.
This enables full tab-completion support for commands like "inet dhcp" which was impossible to implement with existing completion mechanisms.

Add the following new commands, all of which can be tab-completed:

  inet autoconf  (equivalent to autoconf4 command)
  inet dhcp      (likewise equivalent to autoconf4 command)
  inet6 autoconf (equivalent to autoconf6 command)

Also restore the "ip" command as an alias for "inet" such that users who are often typing on Ciscos don't have to adjust their keystrokes. This makes the following commands official again and also work with tab-completion:

  ip autoconf
  ip dhcp