### PR TITLE
leave configuration mode when privileged mode is disabled

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1746,6 +1746,7 @@ int
 disable(void)
 {
 	priv = 0;
+	config_mode = 0;
 	return 0;
 }
 


### PR DESCRIPTION
Configuration mode is supposed to remain nested in privileged mode. Allow the user to fast-quit out of both modes by running 'disable'.

Problem spotted by Tom Smyth