### PR TITLE
provide tab-completion for several "show" commands

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -157,6 +157,30 @@ quit(void)
 	return 0;
 }
 
+char *showroutetab[] = {
+	"<cr>",
+	"<address[/prefix-length]>",
+	NULL
+};
+
+char *showarptab[] = {
+	"<cr>",
+	"<IPv4-address>",
+	NULL
+};
+
+char *showndptab[] = {
+	"<cr>",
+	"<IPv6-address>",
+	NULL
+};
+
+char *showvlantab[] = {
+	"<cr>",
+	"<VLAN Tag>",
+	NULL
+};
+
 /*
  * Data structures and routines for the "show" command.
  */
@@ -165,12 +189,12 @@ Menu showlist[] = {
 	{ "hostname",	"Router hostname",	CMPL0 0, 0, 0, 0, show_hostname },
 	{ "interface",	"Interface config",	CMPL(i) 0, 0, 0, 1, show_int },
 	{ "autoconf",	"IPv4/IPv6 autoconf state", CMPL(i) 0, 0, 0, 1, show_autoconf },
-	{ "route",	"IPv4 route table or route lookup", CMPL0 0, 0, 0, 1, pr_routes },
-	{ "route6",	"IPv6 route table or route lookup", CMPL0 0, 0, 0, 1, pr_routes6 },
+	{ "route",	"IPv4 route table or route lookup", CMPL(h) showroutetab, sizeof(char *), 0, 1, pr_routes },
+	{ "route6",	"IPv6 route table or route lookup", CMPL(h) showroutetab, sizeof(char *), 0, 1, pr_routes6 },
 	{ "sadb",	"Security Association Database", CMPL0 0, 0, 0, 0, pr_sadb },
-	{ "arp",	"ARP table",		CMPL0 0, 0, 0, 1, pr_arp },
-	{ "ndp",	"NDP table",		CMPL0 0, 0, 0, 1, pr_ndp },
-	{ "vlan",	"802.1Q/802.1ad VLANs",	CMPL0 0, 0, 0, 1, show_vlans },
+	{ "arp",	"ARP table",		CMPL(h) showarptab, sizeof(char *), 0, 1, pr_arp },
+	{ "ndp",	"NDP table",		CMPL(h) showndptab, sizeof(char *), 0, 1, pr_ndp },
+	{ "vlan",	"802.1Q/802.1ad VLANs",	CMPL(h) showvlantab, sizeof(char *), 0, 1, show_vlans },
 	{ "bridge",	"Ethernet bridges",	CMPL0 0, 0, 0, 1, show_bridges },
 	{ "kernel",	"Kernel statistics",	CMPL(ta) (char **)stts, sizeof(struct stt), 0, 1, pr_kernel },
 	{ "bgp",	"BGP information",	CMPL(ta) (char **)bgcs, sizeof(struct prot1), 0, 4, pr_prot1 },


### PR DESCRIPTION
These commands now display possible further arguments when tab is pressed: show route, show route6, show arp, now ndp, show vlan