### PR TITLE
cli: tolerate whitespace between interface driver name and unit number

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -769,7 +769,7 @@ interface(int argc, char **argv, char *modhvar)
 			return(1);
 		}
 		strlcat(ifname, ifunit, sizeof(ifname));
-		printf("%% Pro Tip: it is interface %s rather than \"%s %s\"\n",
+		printf("%% Interface name is %s not \"%s %s\"\n",
 		    ifname, tmp, ifunit);
 	}
 	strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));

--- a/if.c
+++ b/if.c
@@ -254,7 +254,7 @@ show_int(int argc, char **argv)
 			return(1);
 		}
 		strlcat(ifname, argv[3], sizeof(ifname));
-		printf("%% Pro Tip: it is interface %s rather than \"%s %s\"\n",
+		printf("%% Interface name is %s not \"%s %s\"\n",
 		    ifname, argv[2], argv[3]);
 	} if (argc == 3)
 		strlcpy(ifname, argv[2], sizeof(ifname));


### PR DESCRIPTION
Suggested by Tom Smyth