### PR TITLE
add show pf commands to nsh (based on pfctl -s [modifier]

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -200,6 +200,7 @@ Menu showlist[] = {
 	{ "bgp",	"BGP information",	CMPL(ta) (char **)bgcs, sizeof(struct prot1), 0, 4, pr_prot1 },
 	{ "ospf",	"OSPF information",	CMPL(ta) (char **)oscs, sizeof(struct prot1), 0, 3, pr_prot1 },
 	{ "ospf6",	"OSPF6 information",	CMPL(ta) (char **)os6cs, sizeof(struct prot1), 0, 3, pr_prot1 },
+	{ "pf",		"Packet Filter firewall information", CMPL(ta) (char **)pfcs, sizeof(struct prot1), 0, 3, pr_prot1 },
 	{ "eigrp",	"EIGRP information",	CMPL(ta) (char **)eics, sizeof(struct prot1), 0, 3, pr_prot1 },
 	{ "rip",	"RIP information",	CMPL(ta) (char **)rics, sizeof(struct prot1), 0, 3, pr_prot1 },
 	{ "ldp",	"LDP information",	CMPL(ta) (char **)lics, sizeof(struct prot1), 0, 3, pr_prot1 },

--- a/commands.h
+++ b/commands.h
@@ -111,6 +111,35 @@ struct prot1 os6cs[] = {
 	{ 0, 0, { 0 } }
 };
 
+struct prot1 pfcs[] = {
+	{ "all",           "all pf info except fingerprints and interfaces", 
+            { PFCTL, "-sall", NULL, NULL, NULL, NULL } },
+	{ "anchors",       "currently loaded anchors in main pf ruleset", 
+            { PFCTL, "-sAnchors", NULL, NULL, NULL } },	
+        { "info ",         "pf filter statistics, counters and tracking",
+            { PFCTL, "-sinfo", "-v", NULL, NULL, NULL } },
+        { "labels",        "per rule stats (bytes, packets and states)",        
+            { PFCTL, "-slabels", NULL, NULL, NULL, NULL } },
+        { "memory",        "current pf pool memory hard limit",
+            { PFCTL, "-smemory", NULL, NULL, NULL, NULL } },
+	{ "queues",        "currently loaded pf queue definition", 
+            { PFCTL, "-squeue", "-v", NULL, NULL, NULL } },
+	{ "rules",         "active pf firewall rule",
+            { PFCTL, "-srules", NULL, NULL, NULL, NULL } },
+	{ "sources",       "contents of the pf source tracking table", 
+            { PFCTL, "-sSources", NULL, NULL, NULL, NULL } },
+	{ "states",        "contents of the pf state table",
+            { PFCTL, "-sstates", NULL, NULL, NULL, NULL } },
+        { "tables",        "pf table",
+            { PFCTL, "-sTables", NULL, NULL, NULL, NULL } },
+	{ "timeouts",      "current pf global timeout", 
+            { PFCTL, "-stimeouts", NULL, NULL, NULL, NULL } },
+	{ "osfingerprint", "pf Operating System fingerprint", 
+            { PFCTL, "-sosfp", NULL, NULL, NULL, NULL } },
+	{ "interfaces",    "pf usable interfaces/ interface group", 
+            { PFCTL, "-sInterfaces", NULL, NULL, NULL, NULL } },
+	{ 0, 0, { 0 } }                                                         
+};
 struct prot1 eics[] = {
 	{ "interfaces",	"Interface",
 	    { EIGRPCTL, "show", "interfaces", OPT, OPT, NULL } },
@@ -221,6 +250,7 @@ struct prot prots[] = {
 	{ "bgp",	bgcs },
 	{ "ospf",	oscs },
 	{ "ospf6",	os6cs },
+	{ "pf",		pfcs },
 	{ "eigrp",	eics },
 	{ "rip",	rics },
 	{ "ike",	ikcs },

--- a/ctl.c
+++ b/ctl.c
@@ -113,14 +113,16 @@ struct ctl ctl_motd[] = {
 /* PF, pfctl */
 char *ctl_pf_test[] = { PFCTL, "-nf", REQTEMP, NULL };
 struct ctl ctl_pf[] = {
-	{ "enable",	"enable service",
+	{ "enable",	"enable pf firewall",
 	    { PFCTL, "-e", NULL }, NULL, DB_X_ENABLE, T_EXEC },
-	{ "disable",	"disable service",
+	{ "disable",	"disable pf firewall",
 	    { PFCTL, "-d", NULL }, NULL, DB_X_DISABLE, T_EXEC },
-	{ "edit",	"edit configuration",
+	{ "edit",	"edit, test and stage firewall rules",
 	    { "pf", (char *)ctl_pf_test, NULL }, call_editor, 0,
 	    T_HANDLER_FILL1 },
-	{ "reload",	"reload service",
+	{ "check-config",     "test and display staged firewall rules",
+            { PFCTL, "-nvvf", REQTEMP, NULL }, NULL, 0, T_EXEC },
+	{ "reload",	"test and apply staged firewall rules",
 	    { PFCTL, "-f", REQTEMP, NULL }, NULL, 0, T_EXEC },
 	{ 0, 0, { 0 }, 0, 0, 0 }
 };

--- a/nsh.8
+++ b/nsh.8
@@ -24,7 +24,7 @@
 .\" (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 .\" THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd $Mdocdate: April 08 2023 $
+.Dd $Mdocdate: April 09 2023 $
 .Dt NSH 8
 .Os
 .Sh NAME
@@ -1673,7 +1673,7 @@ nsh/no verbose
 .Tg show
 .Ic show
 .Op hostname | interface | autoconf | route | route6 | sadb | arp | ndp | vlan\
- | kernel | bgp | ospf | ospf6 | eigrp | rip | ldp | ike | ipsec | dvmrp\
+ | kernel | bgp | ospf | ospf6 | pf | eigrp | rip | ldp | ike | ipsec | dvmrp\
  | relay | dhcp | smtp | ldap | monitor | version | users | running-config\
  | startup-config |\&? | help
 .Pp
@@ -1701,6 +1701,7 @@ nsh(p)/show
   bgp             BGP information
   ospf            OSPF information
   ospf6           OSPF6 information
+  pf              Packet Filter firewall information
   eigrp           EIGRP information
   rip             RIP information
   ldp             LDP information
@@ -2231,6 +2232,56 @@ nsh(p)/show ospf6
   show ospf6 neighbor   Neighbor information
   show ospf6 rib        Routing Information Base information
   show ospf6 summary    Summary information
+nsh(p)/
+.Ed
+.Pp
+.Tg pf
+.Ic show pf
+.Op Ar all | anchors | info | labels | memory | queues | rules | sources |
+ states | tables | timeouts | osfingerprint | interfaces
+.Pp
+Display the status of
+.Xr pf 4
+.Ox
+Packet Filter firewall.
+.Nm uses
+.Xr pfctl 8
+with the -s (show) command with modifier arguments to display various aspects
+the current pf status on the system.
+.Bd -literal -offset indent
+nsh(p)/show pf
+% Arguments may be abbreviated
+
+  show pf all           all pf info except fingerprints and interfaces information
+  show pf anchors       currently loaded anchors in main pf ruleset information
+  show pf info          pf filter statistics, counters and tracking information
+  show pf labels        per rule stats (bytes, packets and states) information
+  show pf memory        current pf pool memory hard limit information
+  show pf queues        currently loaded pf queue definition information
+  show pf rules         active pf firewall rule information
+  show pf sources       contents of the pf source tracking table information
+  show pf states        contents of the pf state table information
+  show pf tables        pf table information
+  show pf timeouts      current pf global timeout information
+  show pf osfingerprint pf Operating System fingerprint information
+  show pf interfaces    pf usable interfaces/ interface group information
+nsh(p)/
+.Ed
+.Tg eigrp
+.Ic show eigrp
+.Op Ar interfaces | neighbor | topology | traffic
+.Pp
+Display the status of
+.Xr eigrpd 8
+Enhanced Interior Gateway Routing Protocol (EIGRP) daemon.
+.Bd -literal -offset indent
+nsh(p)/show eigrp
+% Arguments may be abbreviated
+
+  show eigrp interfaces Interface information
+  show eigrp neighbor   Neighbor information
+  show eigrp topology   Topology information
+  show eigrp traffic    Traffic information
 nsh(p)/
 .Ed
 .Pp

--- a/nsh.8
+++ b/nsh.8
@@ -1,4 +1,4 @@
-.\"     $OpenBSD: nsh.8,v 1.1 2023/04/08 13:22:00 UTC chrisc Exp $
+#.\"     $OpenBSD: nsh.8,v 1.1 2023/04/08 13:22:00 UTC chrisc Exp $
 .\"
 .\" Copyright (c) 2002-2023 Chris Cappuccio.  All rights reserved.
 .\"
@@ -878,36 +878,39 @@ By default pipex is disabled.
 .Bd -literal -offset indent
 nsh(config-p)/pipex enable
 .Ed
+.Pp
 .Tg packetfilter
 .Tg firewall
 .Tg pf
 .Ic pf
-.Op Cm \&? | enable | disable | edit | reload
+.Op Cm \&? | enable | disable | edit | check-config | reload
 .Pp
 Control the configuration and operation of the pf (Packet Filter) firewall.
 .Bd -literal -offset indent
 nsh(config-p)/pf ?
 % Arguments may be abbreviated
 
-   enable  enable service
-   disable disable service
-   edit    edit configuration
-   reload  reload service
+   enable       enable pf firewall
+   disable      disable pf firewall
+   edit         edit, test and stage firewall rules
+   check-config test and display staged firewall rules
+   reload       test and apply staged firewall rules
+nsh(config-p)/
 .Ed
 .Pp
 .Ic pf edit
 .Pp
-Open the default editor for the user and allow the user modify the firewall
-configuration.
+Open the default editor for the user and allow the user modify and stage
+the firewall configuration.
 The edited ruleset is automatically validated by
 .Nm
 with
 .Xr pfctl 8
 on exiting the editor.
-If the user entered pf configuraition is incorrect on exiting the editor
+If the user entered pf configuration is incorrect on exiting the editor,
 .Nm
 will display a syntax error warning with each line number that fails the
-syntax checker.
+syntax check.
 .Pp
 E.g. warning displayed by
 .Cm pf edit
@@ -931,10 +934,27 @@ nsh(p)/!man pf.conf
 nsh(config-p)/pf edit
 .Ed
 .Pp
+.Ic pf check-config
+.Pp
+The
+.Cm pf check-config
+command uses
+.Ox
+.Xr pfctl 8
+to validate the syntax of the staged pf configuration.
+If the staged pf configuration passes the syntax checker, the rules
+will be displayed in order with their rule number.
+If the staged pf configuration fails the syntax checker, the line
+numbers with the syntax errors will be listed.
+.Pp
 .Ic pf reload
+.Pp
 The
 .Cm pf reload
-command validates the syntax of the user entered pf configuration.
+command uses
+.Ox
+.Xr pfctl 8
+to validate the syntax of the staged pf configuration.
 If the
 .Cm pf edit
 config passes,
@@ -959,6 +979,7 @@ nsh(config-p)/pf reload
 /var/run/pf.conf.0:17: syntax error
 pfctl: Syntax error in config file: pf rules not loaded
 .Ed
+.Pp
 .Tg ospf
 .Ic ospf
 .Op Cm \&? | enable | disable | edit | reload | fib | log


### PR DESCRIPTION
add show pf 

show pf 
% Arguments may be abbreviated

  show pf all           all pf info except fingerprints and interfaces information
  show pf anchors       currently loaded anchors in main pf ruleset information
  show pf info          pf filter statistics, counters and tracking information
  show pf labels        per rule stats (bytes, packets and states) information
  show pf memory        current pf pool memory hard limit information
  show pf queues        currently loaded pf queue definition information
  show pf rules         active pf firewall rule information
  show pf sources       contents of the pf source tracking table information
  show pf states        contents of the pf state table information
  show pf tables        pf table information
  show pf timeouts      current pf global timeout information
  show pf osfingerprint pf Operating System fingerprint information
  show pf interfaces    pf usable interfaces/ interface group information
updated the manual with the above and show eigrp  as this was not  previously documented in the manual