### PR TITLE
move  definition of ctl daemons , ctl programs and config file definitions from ctl.c and externs.h to ctl.h 

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -65,6 +65,7 @@
 #include "stringlist.h"
 #include "externs.h"
 #include "sysctl.h"
+#include "ctl.h"
 
 char prompt[128];
 

--- a/conf.c
+++ b/conf.c
@@ -49,6 +49,7 @@
 #include "stringlist.h"
 #include "externs.h"
 #include "bridge.h"
+#include "ctl.h"
 #include "sysctl.h"
 
 #define IPSIZ  256	/*

--- a/ctl.c
+++ b/ctl.c
@@ -26,7 +26,7 @@
 #include <sys/socket.h>
 #include <sys/syslimits.h>
 #include "externs.h"
-
+#include "ctl.h"
 
 /* table variable (for pkill usage) */
 static char table[16];

--- a/ctl.c
+++ b/ctl.c
@@ -82,6 +82,7 @@ struct ctl ctl_motd[] = {
 };
 
 /* PF, pfctl */
+char *ctl_pf_test[] = { PFCTL, "-nf", REQTEMP, NULL };
 struct ctl ctl_pf[] = {
 	{ "enable",	"enable pf firewall",
 	    { PFCTL, "-e", NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -98,6 +99,7 @@ struct ctl ctl_pf[] = {
 };
 
 /* ospfd, ospfctl */
+char *ctl_ospf_test[] = { OSPFD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ospf[] = {
 	{ "enable",     "enable service",
 	    { OSPFD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -118,6 +120,7 @@ struct ctl ctl_ospf[] = {
 };
 
 /* ospf6d, ospf6ctl */
+char *ctl_ospf6_test[] = { OSPF6D, "-nf", REQTEMP, NULL };
 struct ctl ctl_ospf6[] = {
 	{ "enable",     "enable service",
 	    { OSPF6D, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -136,6 +139,7 @@ struct ctl ctl_ospf6[] = {
 };
 
 /* eigrpd, eigrpctl */
+char *ctl_eigrp_test[] = { EIGRPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_eigrp[] = {
 	{ "enable",	"enable service",
 	    { EIGRPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -156,6 +160,7 @@ struct ctl ctl_eigrp[] = {
 };
 
 /* bgpd, bgpctl */
+char *ctl_bgp_test[] = { BGPD, "-nf", REQTEMP, NULL, NULL };
 struct ctl ctl_bgp[] = {
 	{ "enable",     "enable service",
 	    { BGPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -178,6 +183,7 @@ struct ctl ctl_bgp[] = {
 };
 
 /* ripd, ripctl */
+char *ctl_rip_test[] = { RIPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_rip[] = {
 	{ "enable",     "enable service",
 	    { RIPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -196,6 +202,7 @@ struct ctl ctl_rip[] = {
 };
 
 /* ldpd, ldpctl */
+char *ctl_ldp_test[] = { LDPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ldp[] = {
 	{ "enable",	"enable service",
 	   { LDPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -216,6 +223,7 @@ struct ctl ctl_ldp[] = {
 };
 
 /* isakmpd, ipsecctl */
+char *ctl_ipsec_test[] = { IPSECCTL, "-nf", REQTEMP, NULL };
 struct ctl ctl_ipsec[] = {
 	{ "enable",     "enable service",
 	    { ISAKMPD, "-Kv", NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -232,6 +240,7 @@ struct ctl ctl_ipsec[] = {
 };
 
 /* iked, ikectl */
+char *ctl_ike_test[] = { IKED, "-nf", REQTEMP, NULL };
 struct ctl ctl_ike[] = {
 	{ "enable",	"enable service",
 	    { IKED, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -258,6 +267,7 @@ struct ctl ctl_ike[] = {
 };
 
 /* dvmrpd */
+char *ctl_dvmrp_test[] = { DVMRPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_dvmrp[] = {
 	{ "enable",     "enable service",
 	    { DVMRPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -274,6 +284,7 @@ struct ctl ctl_dvmrp[] = {
 };
 
 /* rad */
+char *ctl_rad_test[] = { RAD, "-nf", REQTEMP, NULL };
 struct ctl ctl_rad[] = {
 	{ "enable",	"enable service",
 	    { RAD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -286,6 +297,7 @@ struct ctl ctl_rad[] = {
 };
 
 /* ifstated */
+char *ctl_ifstate_test[] = { IFSTATED, "-nf", REQTEMP, NULL };
 struct ctl ctl_ifstate[] = {
 	{ "enable",     "enable service",
 	    { IFSTATED, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -309,6 +321,7 @@ struct ctl ctl_sasync[] = {
 };
 
 /* npppd, npppctl */
+char *ctl_nppp_test[] = { NPPPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_nppp[] = {
 	{ "enable",	"enable service",
 	    { NPPPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -327,6 +340,7 @@ struct ctl ctl_nppp[] = {
 };
 
 /* dhcpd */
+char *ctl_dhcp_test[] = { DHCPD, "-nc", REQTEMP, NULL };
 struct ctl ctl_dhcp[] = {
 	{ "enable",     "enable service",
 	    { DHCPD, "-c", REQTEMP, "-l", DHCPLEASES, NULL }, NULL, DB_X_ENABLE,
@@ -340,6 +354,7 @@ struct ctl ctl_dhcp[] = {
 };
 
 /* snmpd, snmpctl */
+char *ctl_snmp_test[] = { SNMPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_snmp[] = {
 	{ "enable",     "enable service",
 	    { SNMPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -354,6 +369,7 @@ struct ctl ctl_snmp[] = {
 };
 
 /* sshd */
+char *ctl_sshd_test[] = { SSHD, "-tf", REQTEMP, NULL };
 struct ctl ctl_sshd[] = {
 	{ "enable",	"enable service",
 	    { SSHD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -367,6 +383,7 @@ struct ctl ctl_sshd[] = {
 };
 
 /* ntpd */
+char *ctl_ntp_test[] = { NTPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ntp[] = {
 	{ "enable",     "enable service",
 	    { NTPD, "-sf", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -379,6 +396,7 @@ struct ctl ctl_ntp[] = {
 };
 
 /* relayd, relayctl */
+char *ctl_relay_test[] = { RELAYD, "-nf", REQTEMP, NULL };
 struct ctl ctl_relay[] = {
 	{ "enable",	"enable service",
 	    { RELAYD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -404,7 +422,8 @@ struct ctl ctl_relay[] = {
 	{ 0, 0, { 0 }, 0, 0, 0 }
 };
 
-/* smtpd, smtpctl */
+/* snmpd, snmpctl */
+char *ctl_smtp_test[] = { SMTPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_smtp[] = {
 	{ "enable",	"enable service",
 	    { SMTPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -475,6 +494,7 @@ struct ctl ctl_inet[] = {
 };
 
 /* ldapd, ldapctl */
+char *ctl_ldap_test[] = { LDAPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ldap[] = {
 	{ "enable",	"enable service",
 	    { LDAPD, REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },

--- a/ctl.c
+++ b/ctl.c
@@ -27,35 +27,6 @@
 #include <sys/syslimits.h>
 #include "externs.h"
 
-/* service daemons */
-#define OSPFD		"/usr/sbin/ospfd"
-#define OSPF6D		"/usr/sbin/ospf6d"
-#define EIGRPD		"/usr/sbin/eigrpd"
-#define BGPD		"/usr/sbin/bgpd"
-#define RIPD		"/usr/sbin/ripd"
-#define ISAKMPD		"/sbin/isakmpd"
-#define IKED		"/sbin/iked"
-#define DVMRPD		"/usr/sbin/dvmrpd"
-#define RELAYD		"/usr/sbin/relayd"
-#define DHCPD		"/usr/sbin/dhcpd"
-#define SASYNCD		"/usr/sbin/sasyncd"
-#define	SNMPD		"/usr/sbin/snmpd"
-#define NTPD		"/usr/sbin/ntpd"
-#define FTPPROXY	"/usr/sbin/ftp-proxy"
-#define TFTPPROXY	"/usr/sbin/tftp-proxy"
-#define TFTPD		"/usr/sbin/tftpd"
-#define INETD		"/usr/sbin/inetd"
-#define SSHD		"/usr/sbin/sshd"
-#define LDPD		"/usr/sbin/ldpd"
-#define SMTPD		"/usr/sbin/smtpd"
-#define LDAPD		"/usr/sbin/ldapd"
-#define IFSTATED	"/usr/sbin/ifstated"
-#define NPPPD		"/usr/sbin/npppd"
-#define NPPPCTL		"/usr/sbin/npppctl"
-#define RESOLVD		"/sbin/resolvd"
-#ifndef DHCPLEASES
-#define DHCPLEASES	"/var/db/dhcpd.leases"
-#endif
 
 /* table variable (for pkill usage) */
 static char table[16];
@@ -111,7 +82,6 @@ struct ctl ctl_motd[] = {
 };
 
 /* PF, pfctl */
-char *ctl_pf_test[] = { PFCTL, "-nf", REQTEMP, NULL };
 struct ctl ctl_pf[] = {
 	{ "enable",	"enable pf firewall",
 	    { PFCTL, "-e", NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -128,7 +98,6 @@ struct ctl ctl_pf[] = {
 };
 
 /* ospfd, ospfctl */
-char *ctl_ospf_test[] = { OSPFD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ospf[] = {
 	{ "enable",     "enable service",
 	    { OSPFD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -149,7 +118,6 @@ struct ctl ctl_ospf[] = {
 };
 
 /* ospf6d, ospf6ctl */
-char *ctl_ospf6_test[] = { OSPF6D, "-nf", REQTEMP, NULL };
 struct ctl ctl_ospf6[] = {
 	{ "enable",     "enable service",
 	    { OSPF6D, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -168,7 +136,6 @@ struct ctl ctl_ospf6[] = {
 };
 
 /* eigrpd, eigrpctl */
-char *ctl_eigrp_test[] = { EIGRPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_eigrp[] = {
 	{ "enable",	"enable service",
 	    { EIGRPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -189,7 +156,6 @@ struct ctl ctl_eigrp[] = {
 };
 
 /* bgpd, bgpctl */
-char *ctl_bgp_test[] = { BGPD, "-nf", REQTEMP, NULL, NULL };
 struct ctl ctl_bgp[] = {
 	{ "enable",     "enable service",
 	    { BGPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -212,7 +178,6 @@ struct ctl ctl_bgp[] = {
 };
 
 /* ripd, ripctl */
-char *ctl_rip_test[] = { RIPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_rip[] = {
 	{ "enable",     "enable service",
 	    { RIPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -231,7 +196,6 @@ struct ctl ctl_rip[] = {
 };
 
 /* ldpd, ldpctl */
-char *ctl_ldp_test[] = { LDPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ldp[] = {
 	{ "enable",	"enable service",
 	   { LDPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -252,7 +216,6 @@ struct ctl ctl_ldp[] = {
 };
 
 /* isakmpd, ipsecctl */
-char *ctl_ipsec_test[] = { IPSECCTL, "-nf", REQTEMP, NULL };
 struct ctl ctl_ipsec[] = {
 	{ "enable",     "enable service",
 	    { ISAKMPD, "-Kv", NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -269,7 +232,6 @@ struct ctl ctl_ipsec[] = {
 };
 
 /* iked, ikectl */
-char *ctl_ike_test[] = { IKED, "-nf", REQTEMP, NULL };
 struct ctl ctl_ike[] = {
 	{ "enable",	"enable service",
 	    { IKED, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -296,7 +258,6 @@ struct ctl ctl_ike[] = {
 };
 
 /* dvmrpd */
-char *ctl_dvmrp_test[] = { DVMRPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_dvmrp[] = {
 	{ "enable",     "enable service",
 	    { DVMRPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -313,7 +274,6 @@ struct ctl ctl_dvmrp[] = {
 };
 
 /* rad */
-char *ctl_rad_test[] = { RAD, "-nf", REQTEMP, NULL };
 struct ctl ctl_rad[] = {
 	{ "enable",	"enable service",
 	    { RAD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -326,7 +286,6 @@ struct ctl ctl_rad[] = {
 };
 
 /* ifstated */
-char *ctl_ifstate_test[] = { IFSTATED, "-nf", REQTEMP, NULL };
 struct ctl ctl_ifstate[] = {
 	{ "enable",     "enable service",
 	    { IFSTATED, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -350,7 +309,6 @@ struct ctl ctl_sasync[] = {
 };
 
 /* npppd, npppctl */
-char *ctl_nppp_test[] = { NPPPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_nppp[] = {
 	{ "enable",	"enable service",
 	    { NPPPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -369,7 +327,6 @@ struct ctl ctl_nppp[] = {
 };
 
 /* dhcpd */
-char *ctl_dhcp_test[] = { DHCPD, "-nc", REQTEMP, NULL };
 struct ctl ctl_dhcp[] = {
 	{ "enable",     "enable service",
 	    { DHCPD, "-c", REQTEMP, "-l", DHCPLEASES, NULL }, NULL, DB_X_ENABLE,
@@ -383,7 +340,6 @@ struct ctl ctl_dhcp[] = {
 };
 
 /* snmpd, snmpctl */
-char *ctl_snmp_test[] = { SNMPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_snmp[] = {
 	{ "enable",     "enable service",
 	    { SNMPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -398,7 +354,6 @@ struct ctl ctl_snmp[] = {
 };
 
 /* sshd */
-char *ctl_sshd_test[] = { SSHD, "-tf", REQTEMP, NULL };
 struct ctl ctl_sshd[] = {
 	{ "enable",	"enable service",
 	    { SSHD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -412,7 +367,6 @@ struct ctl ctl_sshd[] = {
 };
 
 /* ntpd */
-char *ctl_ntp_test[] = { NTPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ntp[] = {
 	{ "enable",     "enable service",
 	    { NTPD, "-sf", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -425,7 +379,6 @@ struct ctl ctl_ntp[] = {
 };
 
 /* relayd, relayctl */
-char *ctl_relay_test[] = { RELAYD, "-nf", REQTEMP, NULL };
 struct ctl ctl_relay[] = {
 	{ "enable",	"enable service",
 	    { RELAYD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -451,8 +404,7 @@ struct ctl ctl_relay[] = {
 	{ 0, 0, { 0 }, 0, 0, 0 }
 };
 
-/* snmpd, snmpctl */
-char *ctl_smtp_test[] = { SMTPD, "-nf", REQTEMP, NULL };
+/* smtpd, smtpctl */
 struct ctl ctl_smtp[] = {
 	{ "enable",	"enable service",
 	    { SMTPD, "-f", REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },
@@ -523,7 +475,6 @@ struct ctl ctl_inet[] = {
 };
 
 /* ldapd, ldapctl */
-char *ctl_ldap_test[] = { LDAPD, "-nf", REQTEMP, NULL };
 struct ctl ctl_ldap[] = {
 	{ "enable",	"enable service",
 	    { LDAPD, REQTEMP, NULL }, NULL, DB_X_ENABLE, T_EXEC },

--- a/ctl.h
+++ b/ctl.h
@@ -1,0 +1,139 @@
+/* define constants and functions associated with
+   daemon control */
+
+/* if.c related */
+#define DHCLIENT        "/sbin/dhclient"
+#define DHCRELAY        "/usr/sbin/dhcrelay"
+#define RAD             "/usr/sbin/rad"
+#define DHCPLEASED_SOCK "/dev/dhcpleased.sock"
+#define SLAACD_SOCK     "/dev/slaacd.sock"
+#define IFDATA_MTU 1            /* request for if_data.ifi_mtu */
+#define IFDATA_BAUDRATE 2       /* request for if_data.ifi_baudrate */
+#define IFDATA_IFTYPE 3         /* request for if_data.ifi_type */
+#define MBPS(bps) (bps / 1000 / 1000)
+#define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
+#define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))
+#define ROUNDKBYTES(bytes) ((float)bytes == ((bytes / 1024) * 1024))
+#define DEFAULT_LLPRIORITY 3
+
+/* service daemons */
+#define OSPFD           "/usr/sbin/ospfd"
+#define OSPF6D          "/usr/sbin/ospf6d"
+#define EIGRPD          "/usr/sbin/eigrpd"
+#define BGPD            "/usr/sbin/bgpd"
+#define RIPD            "/usr/sbin/ripd"
+#define ISAKMPD         "/sbin/isakmpd"
+#define IKED            "/sbin/iked"
+#define DVMRPD          "/usr/sbin/dvmrpd"
+#define RELAYD          "/usr/sbin/relayd"
+#define DHCPD           "/usr/sbin/dhcpd"
+#define SASYNCD         "/usr/sbin/sasyncd"
+#define SNMPD           "/usr/sbin/snmpd"  
+#define NTPD            "/usr/sbin/ntpd"
+#define FTPPROXY        "/usr/sbin/ftp-proxy"
+#define TFTPPROXY       "/usr/sbin/tftp-proxy"
+#define TFTPD           "/usr/sbin/tftpd"
+#define INETD           "/usr/sbin/inetd"
+#define SSHD            "/usr/sbin/sshd"
+#define LDPD            "/usr/sbin/ldpd"                                        
+#define SMTPD           "/usr/sbin/smtpd"
+#define LDAPD           "/usr/sbin/ldapd"
+#define IFSTATED        "/usr/sbin/ifstated"
+#define NPPPD           "/usr/sbin/npppd"
+#define NPPPCTL         "/usr/sbin/npppctl"
+#define RESOLVD         "/sbin/resolvd"
+#ifndef DHCPLEASES
+#define DHCPLEASES      "/var/db/dhcpd.leases"
+#endif
+
+/* control programs */   
+#define PFCTL           "/sbin/pfctl"
+#define OSPFCTL         "/usr/sbin/ospfctl"
+#define OSPF6CTL        "/usr/sbin/ospf6ctl"
+#define EIGRPCTL        "/usr/sbin/eigrpctl"
+#define BGPCTL          "/usr/sbin/bgpctl"
+#define RIPCTL          "/usr/sbin/ripctl"
+#define LDPCTL          "/usr/sbin/ldpctl"
+#define IPSECCTL        "/sbin/ipsecctl"
+#define IKECTL          "/usr/sbin/ikectl"
+#define DVMRPCTL        "/usr/sbin/dvmrpctl"
+#define RELAYCTL        "/usr/sbin/relayctl"
+#define SNMPCTL         "/usr/sbin/snmpctl"
+#define SMTPCTL         "/usr/sbin/smtpctl"
+#define LDAPCTL         "/usr/sbin/ldapctl"
+
+/* tmp config locations */
+#define PFCONF_TEMP     "/var/run/pf.conf"
+#define OSPFCONF_TEMP   "/var/run/ospfd.conf"
+#define OSPF6CONF_TEMP  "/var/run/ospf6d.conf"
+#define EIGRPCONF_TEMP  "/var/run/eigrpd.conf"
+#define BGPCONF_TEMP    "/var/run/bgpd.conf"
+#define RIPCONF_TEMP    "/var/run/ripd.conf"
+#define LDPCONF_TEMP    "/var/run/ldpd.conf"
+#define IPSECCONF_TEMP  "/var/run/ipsec.conf"
+#define IKECONF_TEMP    "/var/run/iked.conf"
+#define DVMRPCONF_TEMP  "/var/run/dvmrpd.conf"
+#define RADCONF_TEMP    "/var/run/rad.conf"
+#define RELAYCONF_TEMP  "/var/run/relayd.conf"
+#define SASYNCCONF_TEMP "/var/run/sasyncd.conf"
+#define DHCPCONF_TEMP   "/var/run/dhcpd.conf"
+#define SNMPCONF_TEMP   "/var/run/snmpd.conf"
+#define NTPCONF_TEMP    "/var/run/ntpd.conf"
+#define IFSTATE_TEMP    "/var/run/ifstated.conf"
+#define NPPPCONF_TEMP   "/var/run/npppd.conf"
+#define FTPPROXY_TEMP   "/var/run/ftp-proxy"
+#define TFTPPROXY_TEMP  "/var/run/tftp-proxy"
+#define TFTP_TEMP       "/var/run/tftpd"
+#define INETCONF_TEMP   "/var/run/inetd.conf"
+#define SSHDCONF_TEMP   "/var/run/sshd.conf"
+#define SMTPCONF_TEMP   "/var/run/smtpd.conf"
+#define LDAPCONF_TEMP   "/var/run/ldapd.conf"
+#define IFSTATECONF_TEMP "/var/run/ifstated.conf"
+#define MOTD_TEMP "/var/run/motd"
+
+
+/* if.c related */
+#define DHCLIENT        "/sbin/dhclient"
+#define DHCRELAY        "/usr/sbin/dhcrelay"
+#define RAD             "/usr/sbin/rad"
+#define DHCPLEASED_SOCK "/dev/dhcpleased.sock"
+#define SLAACD_SOCK     "/dev/slaacd.sock"
+#define IFDATA_MTU 1            /* request for if_data.ifi_mtu */
+#define IFDATA_BAUDRATE 2       /* request for if_data.ifi_baudrate */
+#define IFDATA_IFTYPE 3         /* request for if_data.ifi_type */
+#define MBPS(bps) (bps / 1000 / 1000)
+#define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
+#define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))
+#define ROUNDKBYTES(bytes) ((float)bytes == ((bytes / 1024) * 1024))
+#define DEFAULT_LLPRIORITY 3
+
+
+
+
+/* ctl tests*/
+static char *ctl_bgp_test[] = { BGPD, "-nf", REQTEMP, NULL, NULL };
+static char *ctl_dhcp_test[] = { DHCPD, "-nc", REQTEMP, NULL };
+static char *ctl_dvmrp_test[] = { DVMRPD, "-nf", REQTEMP, NULL };
+static char *ctl_eigrp_test[] = { EIGRPD, "-nf", REQTEMP, NULL };
+/* ftpproxy test ? */
+static char *ctl_ifstate_test[] = { IFSTATED, "-nf", REQTEMP, NULL };
+static char *ctl_ike_test[] = { IKED, "-nf", REQTEMP, NULL };
+/* inetd test ? */ 
+static char *ctl_ipsec_test[] = { IPSECCTL, "-nf", REQTEMP, NULL };
+static char *ctl_ldap_test[] = { LDAPD, "-nf", REQTEMP, NULL };
+static char *ctl_ldp_test[] = { LDPD, "-nf", REQTEMP, NULL };
+static char *ctl_nppp_test[] = { NPPPD, "-nf", REQTEMP, NULL };
+static char *ctl_ntp_test[] = { NTPD, "-nf", REQTEMP, NULL };
+static char *ctl_pf_test[] = { PFCTL, "-nf", REQTEMP, NULL };
+static char *ctl_ospf_test[] = { OSPFD, "-nf", REQTEMP, NULL };
+static char *ctl_ospf6_test[] = { OSPF6D, "-nf", REQTEMP, NULL };
+static char *ctl_rad_test[] = { RAD, "-nf", REQTEMP, NULL };
+static char *ctl_relay_test[] = { RELAYD, "-nf", REQTEMP, NULL };
+/* resolvd test ? */
+static char *ctl_rip_test[] = { RIPD, "-nf", REQTEMP, NULL };
+static char *ctl_smtp_test[] = { SMTPD, "-nf", REQTEMP, NULL };
+static char *ctl_snmp_test[] = { SNMPD, "-nf", REQTEMP, NULL };
+static char *ctl_sshd_test[] = { SSHD, "-tf", REQTEMP, NULL };
+/* sasyncd test ? */
+/* tftpd test ? */
+/* tftpproxy test ? */

--- a/ctl.h
+++ b/ctl.h
@@ -62,6 +62,37 @@
 #define SMTPCTL         "/usr/sbin/smtpctl"
 #define LDAPCTL         "/usr/sbin/ldapctl"
 
+/* argument list replacement */
+#define OPT     (void *)1
+#define REQ     (void *)2
+#define IFNAME  (void *)3
+#define REQTEMP (void *)4                                                       
+#define SIZE_CONF_TEMP 64
+int ctlhandler(int, char **, char *);
+void rmtemp(char *);
+struct ctl {
+        char *name;
+        char *help;
+        char *args[32];
+        void (*handler)();
+        int flag_x;
+        int type;
+};
+
+#define T_HANDLER       1
+#define T_HANDLER_FILL1 2
+#define T_EXEC          3
+struct daemons {
+        char *name;
+        char *propername;
+        struct ctl *table;
+        char *tmpfile;
+        mode_t mode;
+        int doreload;
+        int rtablemax;
+};
+
+
 /* tmp config locations */
 #define PFCONF_TEMP     "/var/run/pf.conf"
 #define OSPFCONF_TEMP   "/var/run/ospfd.conf"
@@ -91,25 +122,6 @@
 #define IFSTATECONF_TEMP "/var/run/ifstated.conf"
 #define MOTD_TEMP "/var/run/motd"
 
-
-/* if.c related */
-#define DHCLIENT        "/sbin/dhclient"
-#define DHCRELAY        "/usr/sbin/dhcrelay"
-#define RAD             "/usr/sbin/rad"
-#define DHCPLEASED_SOCK "/dev/dhcpleased.sock"
-#define SLAACD_SOCK     "/dev/slaacd.sock"
-#define IFDATA_MTU 1            /* request for if_data.ifi_mtu */
-#define IFDATA_BAUDRATE 2       /* request for if_data.ifi_baudrate */
-#define IFDATA_IFTYPE 3         /* request for if_data.ifi_type */
-#define MBPS(bps) (bps / 1000 / 1000)
-#define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
-#define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))
-#define ROUNDKBYTES(bytes) ((float)bytes == ((bytes / 1024) * 1024))
-#define DEFAULT_LLPRIORITY 3
-
-
-
-
 /* ctl tests*/
 static char *ctl_bgp_test[] = { BGPD, "-nf", REQTEMP, NULL, NULL };
 static char *ctl_dhcp_test[] = { DHCPD, "-nc", REQTEMP, NULL };
@@ -137,3 +149,34 @@ static char *ctl_sshd_test[] = { SSHD, "-tf", REQTEMP, NULL };
 /* sasyncd test ? */
 /* tftpd test ? */
 /* tftpproxy test ? */
+
+extern struct daemons ctl_daemons[];
+extern struct ctl ctl_pf[];
+extern struct ctl ctl_ospf[];
+extern struct ctl ctl_ospf6[];
+extern struct ctl ctl_eigrp[];
+extern struct ctl ctl_relay[];
+extern struct ctl ctl_bgp[];
+extern struct ctl ctl_rip[];
+extern struct ctl ctl_ldp[];
+extern struct ctl ctl_ipsec[];
+extern struct ctl ctl_nppp[];
+extern struct ctl ctl_ifstate[];
+extern struct ctl ctl_ike[];
+extern struct ctl ctl_dvmrp[];
+extern struct ctl ctl_rad[];
+extern struct ctl ctl_sasync[];
+extern struct ctl ctl_dhcp[];
+extern struct ctl ctl_snmp[];
+extern struct ctl ctl_smtp[];
+extern struct ctl ctl_sshd[];
+extern struct ctl ctl_ntp[];
+extern struct ctl ctl_ftpproxy[];
+extern struct ctl ctl_tftpproxy[];
+extern struct ctl ctl_tftp[];
+extern struct ctl ctl_dns[];
+extern struct ctl ctl_inet[];
+extern struct ctl ctl_ldap[];
+extern struct ctl ctl_motd[];
+extern struct ctl ctl_resolv[];
+void flag_x(char *, char *, int, char *);

--- a/ctl.h
+++ b/ctl.h
@@ -123,29 +123,29 @@ struct daemons {
 #define MOTD_TEMP "/var/run/motd"
 
 /* ctl tests*/
-static char *ctl_bgp_test[] = { BGPD, "-nf", REQTEMP, NULL, NULL };
-static char *ctl_dhcp_test[] = { DHCPD, "-nc", REQTEMP, NULL };
-static char *ctl_dvmrp_test[] = { DVMRPD, "-nf", REQTEMP, NULL };
-static char *ctl_eigrp_test[] = { EIGRPD, "-nf", REQTEMP, NULL };
+extern char *ctl_bgp_test[];
+extern char *ctl_dhcp_test[];
+extern char *ctl_dvmrp_test[];
+extern char *ctl_eigrp_test[];
 /* ftpproxy test ? */
-static char *ctl_ifstate_test[] = { IFSTATED, "-nf", REQTEMP, NULL };
-static char *ctl_ike_test[] = { IKED, "-nf", REQTEMP, NULL };
+extern char *ctl_ifstate_test[];
+extern char *ctl_ike_test[];
 /* inetd test ? */ 
-static char *ctl_ipsec_test[] = { IPSECCTL, "-nf", REQTEMP, NULL };
-static char *ctl_ldap_test[] = { LDAPD, "-nf", REQTEMP, NULL };
-static char *ctl_ldp_test[] = { LDPD, "-nf", REQTEMP, NULL };
-static char *ctl_nppp_test[] = { NPPPD, "-nf", REQTEMP, NULL };
-static char *ctl_ntp_test[] = { NTPD, "-nf", REQTEMP, NULL };
-static char *ctl_pf_test[] = { PFCTL, "-nf", REQTEMP, NULL };
-static char *ctl_ospf_test[] = { OSPFD, "-nf", REQTEMP, NULL };
-static char *ctl_ospf6_test[] = { OSPF6D, "-nf", REQTEMP, NULL };
-static char *ctl_rad_test[] = { RAD, "-nf", REQTEMP, NULL };
-static char *ctl_relay_test[] = { RELAYD, "-nf", REQTEMP, NULL };
+extern char *ctl_ipsec_test[];
+extern char *ctl_ldap_test[];
+extern char *ctl_ldp_test[];
+extern char *ctl_nppp_test[];
+extern char *ctl_ntp_test[];
+extern char *ctl_pf_test[];
+extern char *ctl_ospf_test[];
+extern char *ctl_ospf6_test[];
+extern char *ctl_rad_test[];
+extern char *ctl_relay_test[];
 /* resolvd test ? */
-static char *ctl_rip_test[] = { RIPD, "-nf", REQTEMP, NULL };
-static char *ctl_smtp_test[] = { SMTPD, "-nf", REQTEMP, NULL };
-static char *ctl_snmp_test[] = { SNMPD, "-nf", REQTEMP, NULL };
-static char *ctl_sshd_test[] = { SSHD, "-tf", REQTEMP, NULL };
+extern char *ctl_rip_test[];
+extern char *ctl_smtp_test[];
+extern char *ctl_snmp_test[];
+extern char *ctl_sshd_test[];
 /* sasyncd test ? */
 /* tftpd test ? */
 /* tftpproxy test ? */

--- a/externs.h
+++ b/externs.h
@@ -130,184 +130,7 @@ extern char routeflags[];
 extern char addrnames[];
 extern char metricnames[];
 
-/* ctl.c */
-/* service daemons */
-#define OSPFD           "/usr/sbin/ospfd"
-#define OSPF6D          "/usr/sbin/ospf6d"
-#define EIGRPD          "/usr/sbin/eigrpd"
-#define BGPD            "/usr/sbin/bgpd"
-#define RIPD            "/usr/sbin/ripd"
-#define ISAKMPD         "/sbin/isakmpd"
-#define IKED            "/sbin/iked"
-#define DVMRPD          "/usr/sbin/dvmrpd"
-#define RELAYD          "/usr/sbin/relayd"
-#define DHCPD           "/usr/sbin/dhcpd"
-#define SASYNCD         "/usr/sbin/sasyncd"
-#define SNMPD           "/usr/sbin/snmpd"  
-#define NTPD            "/usr/sbin/ntpd"
-#define FTPPROXY        "/usr/sbin/ftp-proxy"
-#define TFTPPROXY       "/usr/sbin/tftp-proxy"
-#define TFTPD           "/usr/sbin/tftpd"
-#define INETD           "/usr/sbin/inetd"
-#define SSHD            "/usr/sbin/sshd"
-#define LDPD            "/usr/sbin/ldpd"                                        
-#define SMTPD           "/usr/sbin/smtpd"
-#define LDAPD           "/usr/sbin/ldapd"
-#define IFSTATED        "/usr/sbin/ifstated"
-#define NPPPD           "/usr/sbin/npppd"
-#define NPPPCTL         "/usr/sbin/npppctl"
-#define RESOLVD         "/sbin/resolvd"
-#ifndef DHCPLEASES
-#define DHCPLEASES      "/var/db/dhcpd.leases"
-#endif
-
-/* tmp config locations */
-#define PFCONF_TEMP	"/var/run/pf.conf"
-#define OSPFCONF_TEMP	"/var/run/ospfd.conf"
-#define OSPF6CONF_TEMP	"/var/run/ospf6d.conf"
-#define EIGRPCONF_TEMP	"/var/run/eigrpd.conf"
-#define BGPCONF_TEMP	"/var/run/bgpd.conf"
-#define RIPCONF_TEMP	"/var/run/ripd.conf"
-#define LDPCONF_TEMP	"/var/run/ldpd.conf"
-#define IPSECCONF_TEMP	"/var/run/ipsec.conf"
-#define IKECONF_TEMP	"/var/run/iked.conf"
-#define DVMRPCONF_TEMP	"/var/run/dvmrpd.conf"
-#define RADCONF_TEMP	"/var/run/rad.conf"
-#define RELAYCONF_TEMP	"/var/run/relayd.conf"
-#define SASYNCCONF_TEMP	"/var/run/sasyncd.conf"
-#define DHCPCONF_TEMP	"/var/run/dhcpd.conf"
-#define SNMPCONF_TEMP	"/var/run/snmpd.conf"
-#define NTPCONF_TEMP	"/var/run/ntpd.conf"
-#define IFSTATE_TEMP	"/var/run/ifstated.conf"
-#define NPPPCONF_TEMP	"/var/run/npppd.conf"
-#define FTPPROXY_TEMP	"/var/run/ftp-proxy"
-#define TFTPPROXY_TEMP	"/var/run/tftp-proxy"
-#define TFTP_TEMP	"/var/run/tftpd"
-#define INETCONF_TEMP	"/var/run/inetd.conf"
-#define SSHDCONF_TEMP	"/var/run/sshd.conf"
-#define SMTPCONF_TEMP 	"/var/run/smtpd.conf"
-#define LDAPCONF_TEMP	"/var/run/ldapd.conf"
-#define IFSTATECONF_TEMP "/var/run/ifstated.conf"
-#define MOTD_TEMP "/var/run/motd"
-/* if.c related */
-#define DHCLIENT        "/sbin/dhclient"
-#define DHCRELAY        "/usr/sbin/dhcrelay"
-#define RAD             "/usr/sbin/rad"
-#define DHCPLEASED_SOCK "/dev/dhcpleased.sock"
-#define SLAACD_SOCK     "/dev/slaacd.sock"
-#define IFDATA_MTU 1            /* request for if_data.ifi_mtu */
-#define IFDATA_BAUDRATE 2       /* request for if_data.ifi_baudrate */
-#define IFDATA_IFTYPE 3         /* request for if_data.ifi_type */
-#define MBPS(bps) (bps / 1000 / 1000)
-#define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
-#define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))
-#define ROUNDKBYTES(bytes) ((float)bytes == ((bytes / 1024) * 1024))
-#define DEFAULT_LLPRIORITY 3
-
-
-/* control programs */   
-#define PFCTL           "/sbin/pfctl"
-#define OSPFCTL         "/usr/sbin/ospfctl"
-#define OSPF6CTL        "/usr/sbin/ospf6ctl"
-#define EIGRPCTL        "/usr/sbin/eigrpctl"
-#define BGPCTL          "/usr/sbin/bgpctl"
-#define RIPCTL          "/usr/sbin/ripctl"
-#define LDPCTL          "/usr/sbin/ldpctl"
-#define IPSECCTL        "/sbin/ipsecctl"
-#define IKECTL          "/usr/sbin/ikectl"
-#define DVMRPCTL        "/usr/sbin/dvmrpctl"
-#define RELAYCTL        "/usr/sbin/relayctl"
-#define SNMPCTL         "/usr/sbin/snmpctl"
-#define SMTPCTL         "/usr/sbin/smtpctl"
-#define LDAPCTL         "/usr/sbin/ldapctl"
-
-/* argument list replacement */
-#define OPT     (void *)1
-#define REQ     (void *)2
-#define IFNAME  (void *)3
-#define REQTEMP (void *)4
-#define SIZE_CONF_TEMP 64
-int ctlhandler(int, char **, char *);
-void rmtemp(char *);
-
-/* ctl tests*/
-static char *ctl_bgp_test[] = { BGPD, "-nf", REQTEMP, NULL, NULL };
-static char *ctl_dhcp_test[] = { DHCPD, "-nc", REQTEMP, NULL };
-static char *ctl_dvmrp_test[] = { DVMRPD, "-nf", REQTEMP, NULL };
-static char *ctl_eigrp_test[] = { EIGRPD, "-nf", REQTEMP, NULL };
-/* ftpproxy test ? */
-static char *ctl_ifstate_test[] = { IFSTATED, "-nf", REQTEMP, NULL };
-static char *ctl_ike_test[] = { IKED, "-nf", REQTEMP, NULL };
-/* inetd test ? */ 
-static char *ctl_ipsec_test[] = { IPSECCTL, "-nf", REQTEMP, NULL };
-static char *ctl_ldap_test[] = { LDAPD, "-nf", REQTEMP, NULL };
-static char *ctl_ldp_test[] = { LDPD, "-nf", REQTEMP, NULL };
-static char *ctl_nppp_test[] = { NPPPD, "-nf", REQTEMP, NULL };
-static char *ctl_ntp_test[] = { NTPD, "-nf", REQTEMP, NULL };
-static char *ctl_pf_test[] = { PFCTL, "-nf", REQTEMP, NULL };
-static char *ctl_ospf_test[] = { OSPFD, "-nf", REQTEMP, NULL };
-static char *ctl_ospf6_test[] = { OSPF6D, "-nf", REQTEMP, NULL };
-static char *ctl_rad_test[] = { RAD, "-nf", REQTEMP, NULL };
-static char *ctl_relay_test[] = { RELAYD, "-nf", REQTEMP, NULL };
-/* resolvd test ? */
-static char *ctl_rip_test[] = { RIPD, "-nf", REQTEMP, NULL };
-static char *ctl_smtp_test[] = { SMTPD, "-nf", REQTEMP, NULL };
-static char *ctl_snmp_test[] = { SNMPD, "-nf", REQTEMP, NULL };
-static char *ctl_sshd_test[] = { SSHD, "-tf", REQTEMP, NULL };
-/* sasyncd test ? */
-/* tftpd test ? */
-/* tftpproxy test ? */
-
-struct ctl {
-	char *name;
-	char *help;
-	char *args[32];
-	void (*handler)();
-	int flag_x;
-	int type;
-};
-#define	T_HANDLER	1
-#define T_HANDLER_FILL1	2
-#define	T_EXEC		3
-struct daemons {
-        char *name;
-	char *propername;
-        struct ctl *table;
-        char *tmpfile;
-	mode_t mode;
-	int doreload;
-	int rtablemax;
-};
-extern struct daemons ctl_daemons[];
-extern struct ctl ctl_pf[];
-extern struct ctl ctl_ospf[];
-extern struct ctl ctl_ospf6[];
-extern struct ctl ctl_eigrp[];
-extern struct ctl ctl_relay[];
-extern struct ctl ctl_bgp[];
-extern struct ctl ctl_rip[];
-extern struct ctl ctl_ldp[];
-extern struct ctl ctl_ipsec[];
-extern struct ctl ctl_nppp[];
-extern struct ctl ctl_ifstate[];
-extern struct ctl ctl_ike[];
-extern struct ctl ctl_dvmrp[];
-extern struct ctl ctl_rad[];
-extern struct ctl ctl_sasync[];
-extern struct ctl ctl_dhcp[];
-extern struct ctl ctl_snmp[];
-extern struct ctl ctl_smtp[];
-extern struct ctl ctl_sshd[];
-extern struct ctl ctl_ntp[];
-extern struct ctl ctl_ftpproxy[];
-extern struct ctl ctl_tftpproxy[];
-extern struct ctl ctl_tftp[];
-extern struct ctl ctl_dns[];
-extern struct ctl ctl_inet[];
-extern struct ctl ctl_ldap[];
-extern struct ctl ctl_motd[];
-extern struct ctl ctl_resolv[];
-void flag_x(char *, char *, int, char *);
+/* ctl.c declarations moved to ctl.h */
 
 /* commands.c */
 #define NOPTFILL	7
@@ -453,6 +276,19 @@ int parse_ipv6(char *, struct in6_addr *);
 #endif
 
 /* if.c */
+#define DHCLIENT	"/sbin/dhclient"
+#define DHCRELAY	"/usr/sbin/dhcrelay"
+#define RAD		"/usr/sbin/rad"
+#define DHCPLEASED_SOCK	"/dev/dhcpleased.sock"
+#define SLAACD_SOCK	"/dev/slaacd.sock"
+#define IFDATA_MTU 1		/* request for if_data.ifi_mtu */
+#define IFDATA_BAUDRATE 2	/* request for if_data.ifi_baudrate */
+#define IFDATA_IFTYPE 3		/* request for if_data.ifi_type */
+#define MBPS(bps) (bps / 1000 / 1000)
+#define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
+#define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))
+#define ROUNDKBYTES(bytes) ((float)bytes == ((bytes / 1024) * 1024))
+#define DEFAULT_LLPRIORITY 3
 void imr_init(char *);
 int is_valid_ifname(char *);
 int show_int(int, char **);

--- a/externs.h
+++ b/externs.h
@@ -131,6 +131,36 @@ extern char addrnames[];
 extern char metricnames[];
 
 /* ctl.c */
+/* service daemons */
+#define OSPFD           "/usr/sbin/ospfd"
+#define OSPF6D          "/usr/sbin/ospf6d"
+#define EIGRPD          "/usr/sbin/eigrpd"
+#define BGPD            "/usr/sbin/bgpd"
+#define RIPD            "/usr/sbin/ripd"
+#define ISAKMPD         "/sbin/isakmpd"
+#define IKED            "/sbin/iked"
+#define DVMRPD          "/usr/sbin/dvmrpd"
+#define RELAYD          "/usr/sbin/relayd"
+#define DHCPD           "/usr/sbin/dhcpd"
+#define SASYNCD         "/usr/sbin/sasyncd"
+#define SNMPD           "/usr/sbin/snmpd"  
+#define NTPD            "/usr/sbin/ntpd"
+#define FTPPROXY        "/usr/sbin/ftp-proxy"
+#define TFTPPROXY       "/usr/sbin/tftp-proxy"
+#define TFTPD           "/usr/sbin/tftpd"
+#define INETD           "/usr/sbin/inetd"
+#define SSHD            "/usr/sbin/sshd"
+#define LDPD            "/usr/sbin/ldpd"                                        
+#define SMTPD           "/usr/sbin/smtpd"
+#define LDAPD           "/usr/sbin/ldapd"
+#define IFSTATED        "/usr/sbin/ifstated"
+#define NPPPD           "/usr/sbin/npppd"
+#define NPPPCTL         "/usr/sbin/npppctl"
+#define RESOLVD         "/sbin/resolvd"
+#ifndef DHCPLEASES
+#define DHCPLEASES      "/var/db/dhcpd.leases"
+#endif
+
 /* tmp config locations */
 #define PFCONF_TEMP	"/var/run/pf.conf"
 #define OSPFCONF_TEMP	"/var/run/ospfd.conf"
@@ -159,6 +189,37 @@ extern char metricnames[];
 #define LDAPCONF_TEMP	"/var/run/ldapd.conf"
 #define IFSTATECONF_TEMP "/var/run/ifstated.conf"
 #define MOTD_TEMP "/var/run/motd"
+/* if.c related */
+#define DHCLIENT        "/sbin/dhclient"
+#define DHCRELAY        "/usr/sbin/dhcrelay"
+#define RAD             "/usr/sbin/rad"
+#define DHCPLEASED_SOCK "/dev/dhcpleased.sock"
+#define SLAACD_SOCK     "/dev/slaacd.sock"
+#define IFDATA_MTU 1            /* request for if_data.ifi_mtu */
+#define IFDATA_BAUDRATE 2       /* request for if_data.ifi_baudrate */
+#define IFDATA_IFTYPE 3         /* request for if_data.ifi_type */
+#define MBPS(bps) (bps / 1000 / 1000)
+#define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
+#define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))
+#define ROUNDKBYTES(bytes) ((float)bytes == ((bytes / 1024) * 1024))
+#define DEFAULT_LLPRIORITY 3
+
+
+/* control programs */   
+#define PFCTL           "/sbin/pfctl"
+#define OSPFCTL         "/usr/sbin/ospfctl"
+#define OSPF6CTL        "/usr/sbin/ospf6ctl"
+#define EIGRPCTL        "/usr/sbin/eigrpctl"
+#define BGPCTL          "/usr/sbin/bgpctl"
+#define RIPCTL          "/usr/sbin/ripctl"
+#define LDPCTL          "/usr/sbin/ldpctl"
+#define IPSECCTL        "/sbin/ipsecctl"
+#define IKECTL          "/usr/sbin/ikectl"
+#define DVMRPCTL        "/usr/sbin/dvmrpctl"
+#define RELAYCTL        "/usr/sbin/relayctl"
+#define SNMPCTL         "/usr/sbin/snmpctl"
+#define SMTPCTL         "/usr/sbin/smtpctl"
+#define LDAPCTL         "/usr/sbin/ldapctl"
 
 /* argument list replacement */
 #define OPT     (void *)1
@@ -168,21 +229,35 @@ extern char metricnames[];
 #define SIZE_CONF_TEMP 64
 int ctlhandler(int, char **, char *);
 void rmtemp(char *);
-/* control programs */
-#define PFCTL		"/sbin/pfctl"
-#define OSPFCTL		"/usr/sbin/ospfctl"
-#define OSPF6CTL	"/usr/sbin/ospf6ctl"
-#define EIGRPCTL	"/usr/sbin/eigrpctl"
-#define BGPCTL		"/usr/sbin/bgpctl"
-#define RIPCTL		"/usr/sbin/ripctl"
-#define LDPCTL		"/usr/sbin/ldpctl"
-#define IPSECCTL	"/sbin/ipsecctl"
-#define IKECTL		"/usr/sbin/ikectl"
-#define DVMRPCTL	"/usr/sbin/dvmrpctl"
-#define RELAYCTL	"/usr/sbin/relayctl"
-#define SNMPCTL		"/usr/sbin/snmpctl"
-#define SMTPCTL		"/usr/sbin/smtpctl"
-#define LDAPCTL		"/usr/sbin/ldapctl"
+
+/* ctl tests*/
+static char *ctl_bgp_test[] = { BGPD, "-nf", REQTEMP, NULL, NULL };
+static char *ctl_dhcp_test[] = { DHCPD, "-nc", REQTEMP, NULL };
+static char *ctl_dvmrp_test[] = { DVMRPD, "-nf", REQTEMP, NULL };
+static char *ctl_eigrp_test[] = { EIGRPD, "-nf", REQTEMP, NULL };
+/* ftpproxy test ? */
+static char *ctl_ifstate_test[] = { IFSTATED, "-nf", REQTEMP, NULL };
+static char *ctl_ike_test[] = { IKED, "-nf", REQTEMP, NULL };
+/* inetd test ? */ 
+static char *ctl_ipsec_test[] = { IPSECCTL, "-nf", REQTEMP, NULL };
+static char *ctl_ldap_test[] = { LDAPD, "-nf", REQTEMP, NULL };
+static char *ctl_ldp_test[] = { LDPD, "-nf", REQTEMP, NULL };
+static char *ctl_nppp_test[] = { NPPPD, "-nf", REQTEMP, NULL };
+static char *ctl_ntp_test[] = { NTPD, "-nf", REQTEMP, NULL };
+static char *ctl_pf_test[] = { PFCTL, "-nf", REQTEMP, NULL };
+static char *ctl_ospf_test[] = { OSPFD, "-nf", REQTEMP, NULL };
+static char *ctl_ospf6_test[] = { OSPF6D, "-nf", REQTEMP, NULL };
+static char *ctl_rad_test[] = { RAD, "-nf", REQTEMP, NULL };
+static char *ctl_relay_test[] = { RELAYD, "-nf", REQTEMP, NULL };
+/* resolvd test ? */
+static char *ctl_rip_test[] = { RIPD, "-nf", REQTEMP, NULL };
+static char *ctl_smtp_test[] = { SMTPD, "-nf", REQTEMP, NULL };
+static char *ctl_snmp_test[] = { SNMPD, "-nf", REQTEMP, NULL };
+static char *ctl_sshd_test[] = { SSHD, "-tf", REQTEMP, NULL };
+/* sasyncd test ? */
+/* tftpd test ? */
+/* tftpproxy test ? */
+
 struct ctl {
 	char *name;
 	char *help;
@@ -378,19 +453,6 @@ int parse_ipv6(char *, struct in6_addr *);
 #endif
 
 /* if.c */
-#define DHCLIENT	"/sbin/dhclient"
-#define DHCRELAY	"/usr/sbin/dhcrelay"
-#define RAD		"/usr/sbin/rad"
-#define DHCPLEASED_SOCK	"/dev/dhcpleased.sock"
-#define SLAACD_SOCK	"/dev/slaacd.sock"
-#define IFDATA_MTU 1		/* request for if_data.ifi_mtu */
-#define IFDATA_BAUDRATE 2	/* request for if_data.ifi_baudrate */
-#define IFDATA_IFTYPE 3		/* request for if_data.ifi_type */
-#define MBPS(bps) (bps / 1000 / 1000)
-#define ROUNDMBPS(bps) ((float)bps == ((bps / 1000 / 1000) * 1000 * 1000))
-#define ROUNDKBPS(bps) ((float)bps == ((bps / 1000) * 1000))
-#define ROUNDKBYTES(bytes) ((float)bytes == ((bytes / 1024) * 1024))
-#define DEFAULT_LLPRIORITY 3
 void imr_init(char *);
 int is_valid_ifname(char *);
 int show_int(int, char **);

--- a/if.c
+++ b/if.c
@@ -51,7 +51,6 @@
 #include "externs.h"
 #include "ctl.h"
 
-
 char *iftype(int int_type);
 const char *get_linkstate(int, int);
 void show_int_status(char *, int);

--- a/if.c
+++ b/if.c
@@ -49,6 +49,8 @@
 #include "bridge.h"
 #include "stringlist.h"
 #include "externs.h"
+#include "ctl.h"
+
 
 char *iftype(int int_type);
 const char *get_linkstate(int, int);

--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@
 #include "editing.h"
 #include "stringlist.h"
 #include "externs.h"
+#include "ctl.h"
 
 void usage(void);
 

--- a/route.c
+++ b/route.c
@@ -29,6 +29,7 @@
 #include <arpa/inet.h>
 #include "ip.h"
 #include "externs.h"
+#include "ctl.h"
 
 #define ASSUME_NETMASK 1
 

--- a/route.c
+++ b/route.c
@@ -29,7 +29,6 @@
 #include <arpa/inet.h>
 #include "ip.h"
 #include "externs.h"
-#include "ctl.h"
 
 #define ASSUME_NETMASK 1
 


### PR DESCRIPTION
move  definition of ctl daemons from ctl.c to externs.h   move ctl tests for daemon config syntax from ctl.c to externs.h this is to facilitate using ctl tests from other  files such as commands.c modify function declaration to include static to avoid duplicate symbols at compile time ...