### PR TITLE
ignore extra argument to 'show int' if we already have a valid interface

### DIFF
--- a/if.c
+++ b/if.c
@@ -256,10 +256,15 @@ show_int(int argc, char **argv)
 		 * network switches do: interface em 0
 		 */
 		const char *errstr;
+		size_t len2 = strlen(argv[2]);
 		strlcpy(ifname, argv[2], sizeof(ifname));
 		strtonum(argv[3], 0, INT_MAX, &errstr);
 		if (errstr) {
 			printf("%% interface unit %s is %s\n", argv[3], errstr);
+			return(1);
+		}
+		if (len2 > 0 && isdigit((unsigned char)(argv[2][len2 - 1]))) {
+			printf("%% interface unit %s is redundant\n", argv[3]);
 			return(1);
 		}
 		strlcat(ifname, argv[3], sizeof(ifname));


### PR DESCRIPTION
Otherwise we see an error like the following when the user accidentally enters extra numbers: Interface name is vlan1004093 not "vlan100 4093"  Now we will show vlan100 instead in this case.

Problem found by Tom Smyth