### PR TITLE
reject redundant interface unit arguments to interface command

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -795,9 +795,14 @@ interface(int argc, char **argv, char *modhvar)
 	strlcpy(ifname, tmp, IFNAMSIZ);
 	if (ifunit) {
 		const char *errstr;
+		size_t len = strlen(ifname);
 		strtonum(ifunit, 0, INT_MAX, &errstr);
 		if (errstr) {
 			printf("%% interface unit %s is %s\n", ifunit, errstr);
+			return(1);
+		}
+		if (len > 0 && isdigit((unsigned char)(ifname[len - 1]))) {
+			printf("%% interface unit %s is redundant\n", ifunit);
 			return(1);
 		}
 		strlcat(ifname, ifunit, sizeof(ifname));


### PR DESCRIPTION
Otherwise we end up creating a badly named interface in case the user enters extra digits:

nsh(config-p)/interface vlan100 200
% Interface name is vlan100200 not "vlan100 200"
nsh(interface-vlan100200)/

Problem spotted by Tom Smyth.