### PR TITLE
Intcontext diag

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -123,6 +123,7 @@ static int	int_traceroute6(char *, int, int, char **);
 static int	int_ssh(char *, int, int, char **);
 static int	int_telnet(char *, int, int, char **);
 static int	int_show(char *, int, int, char **);
+static int	int_who(char *, int, int, char **);
 static int	int_doverbose(char *, int, int, char **);
 static int	int_doediting(char *, int, int, char **);
 static int	int_manual(char *, int, int, char **);
@@ -570,6 +571,7 @@ static char tracert6help[];
 static char sshhelp[];
 static char telnethelp[];
 static char showhelp[];
+static char whohelp[];
 static char verbosehelp[];
 static char editinghelp[];
 static char manhelp[];
@@ -665,6 +667,7 @@ struct intlist Intlist[] = {
 	{ "trunkproto",	"Define trunkproto",			CMPL0 0, 0, inttrunkproto, 1 },
 	{ "shutdown",   "Shutdown interface",			CMPL0 0, 0, intflags, 1 },
 	{ "show",	showhelp,				CMPL(ta) (char **)showlist, sizeof(Menu), int_show, 0 },
+	{ "who",	whohelp,				CMPL0 0, 0, int_who, 0 },
 	{ "verbose",	verbosehelp,				CMPL0 0, 0, int_doverbose, 1 },
 	{ "editing",	editinghelp,				CMPL0 0, 0, int_doediting, 1 },
         { "?",		"Options",				CMPL0 0, 0, int_help, 0 },
@@ -712,6 +715,7 @@ struct intlist Bridgelist[] = {
 	{ "protect",	"Configure protected bridge domains",	CMPL0 0, 0, brprotect, 1 },
 	{ "shutdown",	"Shutdown bridge",			CMPL0 0, 0, intflags, 1 },
 	{ "show",	showhelp,				CMPL(ta) (char **)showlist, sizeof(Menu), int_show, 0 },
+	{ "who",	whohelp,				CMPL0 0, 0, int_who, 0 },
 	{ "verbose",	verbosehelp,				CMPL0 0, 0, int_doverbose, 1 },
 	{ "editing",	editinghelp,				CMPL0 0, 0, int_doediting, 1 },
 
@@ -1040,6 +1044,13 @@ static int
 int_show(char *ifname, int ifs, int argc, char **argv)
 {
 	showcmd(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_who(char *ifname, int ifs, int argc, char **argv)
+{
+	who(argc, argv);
 	return 0; /* do not leave interface context */
 }
 

--- a/commands.c
+++ b/commands.c
@@ -116,6 +116,7 @@ static int	flush_ndp_cache(void);
 static int	flush_history(void);
 static int	is_bad_input(const char *, size_t);
 static int	read_command_line(EditLine *, History *);
+static int	int_show(char *, int, int, char **);
 static int	int_help(void);
 static int	int_exit(void);
 static int	el_burrito(EditLine *, int, char **);
@@ -553,6 +554,8 @@ flush_help(void)
  * Data structures and routines for the interface configuration mode
  */
 
+static char showhelp[];
+
 struct intlist Intlist[] = {
 /* Interface mode commands */
 	{ "inet",	"IPv4/IPv6 addresses",			CMPL(h) (char **)intiphelp, sizeof(struct ghs), intip, 1},
@@ -636,6 +639,7 @@ struct intlist Intlist[] = {
 	{ "trunkport",	"Add child interface(s) to trunk",	CMPL0 0, 0, inttrunkport, 1 },
 	{ "trunkproto",	"Define trunkproto",			CMPL0 0, 0, inttrunkproto, 1 },
 	{ "shutdown",   "Shutdown interface",			CMPL0 0, 0, intflags, 1 },
+	{ "show",	showhelp,				CMPL(ta) (char **)showlist, sizeof(Menu), int_show, 0 },
         { "?",		"Options",				CMPL0 0, 0, int_help, 0 },
         { "help",	0,					CMPL0 0, 0, int_help, 0 },
 	{ "exit",	"Leave interface config mode and return to global config mode ",
@@ -673,6 +677,7 @@ struct intlist Bridgelist[] = {
 	{ "tunneldomain", "Tunnel parameters",			CMPL0 0, 0, intmpls, 1 },
 	{ "protect",	"Configure protected bridge domains",	CMPL0 0, 0, brprotect, 1 },
 	{ "shutdown",	"Shutdown bridge",			CMPL0 0, 0, intflags, 1 },
+	{ "show",	showhelp,				CMPL(ta) (char **)showlist, sizeof(Menu), int_show, 0 },
 
 /* Help commands */
 	{ "?",		"Options",				CMPL0 0, 0, int_help, 0 },
@@ -950,6 +955,13 @@ interface(int argc, char **argv, char *modhvar)
 
 	close(ifs);
 	return(0);
+}
+
+static int
+int_show(char *ifname, int ifs, int argc, char **argv)
+{
+	showcmd(argc, argv);
+	return 0; /* do not leave interface context */
 }
 
 static int

--- a/commands.c
+++ b/commands.c
@@ -117,6 +117,7 @@ static int	flush_history(void);
 static int	is_bad_input(const char *, size_t);
 static int	read_command_line(EditLine *, History *);
 static int	int_show(char *, int, int, char **);
+static int	int_manual(char *, int, int, char **);
 static int	int_help(void);
 static int	int_exit(void);
 static int	el_burrito(EditLine *, int, char **);
@@ -555,6 +556,8 @@ flush_help(void)
  */
 
 static char showhelp[];
+static char manhelp[];
+struct ghs mantab[];
 
 struct intlist Intlist[] = {
 /* Interface mode commands */
@@ -641,6 +644,7 @@ struct intlist Intlist[] = {
 	{ "shutdown",   "Shutdown interface",			CMPL0 0, 0, intflags, 1 },
 	{ "show",	showhelp,				CMPL(ta) (char **)showlist, sizeof(Menu), int_show, 0 },
         { "?",		"Options",				CMPL0 0, 0, int_help, 0 },
+	{ "manual",	manhelp,				CMPL(H) (char **)mantab, sizeof(struct ghs), int_manual, 0 },
         { "help",	0,					CMPL0 0, 0, int_help, 0 },
 	{ "exit",	"Leave interface config mode and return to global config mode ",
 								CMPL0 0, 0, int_exit, 0 },
@@ -681,6 +685,7 @@ struct intlist Bridgelist[] = {
 
 /* Help commands */
 	{ "?",		"Options",				CMPL0 0, 0, int_help, 0 },
+	{ "manual",	manhelp,				CMPL(H) (char **)mantab, sizeof(struct ghs), int_manual, 0 },
 	{ "help",	0,					CMPL0 0, 0, int_help, 0 },
 	{ "exit",	"Leave bridge config mode and return to global config mode ",
 								CMPL0 0, 0, int_exit },
@@ -961,6 +966,13 @@ static int
 int_show(char *ifname, int ifs, int argc, char **argv)
 {
 	showcmd(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_manual(char *ifname, int ifs, int argc, char **argv)
+{
+	manual(argc, argv);
 	return 0; /* do not leave interface context */
 }
 

--- a/commands.c
+++ b/commands.c
@@ -118,6 +118,8 @@ static int	is_bad_input(const char *, size_t);
 static int	read_command_line(EditLine *, History *);
 static int	int_ping(char *, int, int, char **);
 static int	int_ping6(char *, int, int, char **);
+static int	int_traceroute(char *, int, int, char **);
+static int	int_traceroute6(char *, int, int, char **);
 static int	int_show(char *, int, int, char **);
 static int	int_manual(char *, int, int, char **);
 static int	int_help(void);
@@ -559,6 +561,8 @@ flush_help(void)
 
 static char pinghelp[];
 static char ping6help[];
+static char tracerthelp[];
+static char tracert6help[];
 static char showhelp[];
 static char manhelp[];
 struct ghs mantab[];
@@ -610,6 +614,8 @@ struct intlist Intlist[] = {
 	{ "patch",	"Pair interface",			CMPL(i) 0, 0, intpatch, 1 },
 	{ "ping",	pinghelp,				CMPL0 0, 0, int_ping, 0 },
 	{ "ping6",	ping6help,				CMPL0 0, 0, int_ping6, 0 },
+	{ "traceroute", tracerthelp,				CMPL0 0, 0, int_traceroute, 0 },
+	{ "traceroute6", tracert6help,				CMPL0 0, 0, int_traceroute6, 0 },
 	{ "keepalive",	"GRE tunnel keepalive",			CMPL0 0, 0, intkeepalive, 1},
 	{ "mplslabel",	"MPLS local label",			CMPL0 0, 0, intmpls, 1 },
 	{ "pwe",	"MPLS PWE3",				CMPL0 0, 0, intpwe3, 1 },
@@ -677,6 +683,8 @@ struct intlist Bridgelist[] = {
 	{ "priority",	"Spanning priority for all members on an 802.1D bridge",CMPL0 0, 0, brval, 1},
 	{ "ping",	pinghelp,				CMPL0 0, 0, int_ping, 0 },
 	{ "ping6",	ping6help,				CMPL0 0, 0, int_ping6, 0 },
+	{ "traceroute", tracerthelp,				CMPL0 0, 0, int_traceroute, 0 },
+	{ "traceroute6", tracert6help,				CMPL0 0, 0, int_traceroute6, 0 },
 	{ "rule",	"Bridge layer 2 filtering rules",	CMPL0 0, 0, brrule, 0 },
 	{ "static",	"Static bridge address entry",		CMPL0 0, 0, brstatic, 1 },
 	{ "ifpriority",	"Spanning priority of a member on an 802.1D bridge",	CMPL0 0, 0, brpri, 1 },
@@ -981,6 +989,20 @@ static int
 int_ping6(char *ifname, int ifs, int argc, char **argv)
 {
 	ping6(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_traceroute(char *ifname, int ifs, int argc, char **argv)
+{
+	traceroute(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_traceroute6(char *ifname, int ifs, int argc, char **argv)
+{
+	traceroute6(argc, argv);
 	return 0; /* do not leave interface context */
 }
 

--- a/commands.c
+++ b/commands.c
@@ -120,6 +120,8 @@ static int	int_ping(char *, int, int, char **);
 static int	int_ping6(char *, int, int, char **);
 static int	int_traceroute(char *, int, int, char **);
 static int	int_traceroute6(char *, int, int, char **);
+static int	int_ssh(char *, int, int, char **);
+static int	int_telnet(char *, int, int, char **);
 static int	int_show(char *, int, int, char **);
 static int	int_manual(char *, int, int, char **);
 static int	int_help(void);
@@ -563,6 +565,8 @@ static char pinghelp[];
 static char ping6help[];
 static char tracerthelp[];
 static char tracert6help[];
+static char sshhelp[];
+static char telnethelp[];
 static char showhelp[];
 static char manhelp[];
 struct ghs mantab[];
@@ -616,6 +620,8 @@ struct intlist Intlist[] = {
 	{ "ping6",	ping6help,				CMPL0 0, 0, int_ping6, 0 },
 	{ "traceroute", tracerthelp,				CMPL0 0, 0, int_traceroute, 0 },
 	{ "traceroute6", tracert6help,				CMPL0 0, 0, int_traceroute6, 0 },
+	{ "ssh",	sshhelp,				CMPL0 0, 0, int_ssh, 0 },
+	{ "telnet",	telnethelp,				CMPL0 0, 0, int_telnet,	0 },
 	{ "keepalive",	"GRE tunnel keepalive",			CMPL0 0, 0, intkeepalive, 1},
 	{ "mplslabel",	"MPLS local label",			CMPL0 0, 0, intmpls, 1 },
 	{ "pwe",	"MPLS PWE3",				CMPL0 0, 0, intpwe3, 1 },
@@ -685,6 +691,8 @@ struct intlist Bridgelist[] = {
 	{ "ping6",	ping6help,				CMPL0 0, 0, int_ping6, 0 },
 	{ "traceroute", tracerthelp,				CMPL0 0, 0, int_traceroute, 0 },
 	{ "traceroute6", tracert6help,				CMPL0 0, 0, int_traceroute6, 0 },
+	{ "ssh",	sshhelp,				CMPL0 0, 0, int_ssh, 0 },
+	{ "telnet",	telnethelp,				CMPL0 0, 0, int_telnet,	0 },
 	{ "rule",	"Bridge layer 2 filtering rules",	CMPL0 0, 0, brrule, 0 },
 	{ "static",	"Static bridge address entry",		CMPL0 0, 0, brstatic, 1 },
 	{ "ifpriority",	"Spanning priority of a member on an 802.1D bridge",	CMPL0 0, 0, brpri, 1 },
@@ -1003,6 +1011,20 @@ static int
 int_traceroute6(char *ifname, int ifs, int argc, char **argv)
 {
 	traceroute6(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_ssh(char *ifname, int ifs, int argc, char **argv)
+{
+	ssh(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_telnet(char *ifname, int ifs, int argc, char **argv)
+{
+	telnet(argc, argv);
 	return 0; /* do not leave interface context */
 }
 

--- a/commands.c
+++ b/commands.c
@@ -127,6 +127,7 @@ static int	int_who(char *, int, int, char **);
 static int	int_doverbose(char *, int, int, char **);
 static int	int_doediting(char *, int, int, char **);
 static int	int_manual(char *, int, int, char **);
+static int	int_shell(char *, int, int, char **);
 static int	int_help(void);
 static int	int_exit(void);
 static int	el_burrito(EditLine *, int, char **);
@@ -574,6 +575,7 @@ static char showhelp[];
 static char whohelp[];
 static char verbosehelp[];
 static char editinghelp[];
+static char shellhelp[];
 static char manhelp[];
 struct ghs mantab[];
 
@@ -670,6 +672,7 @@ struct intlist Intlist[] = {
 	{ "who",	whohelp,				CMPL0 0, 0, int_who, 0 },
 	{ "verbose",	verbosehelp,				CMPL0 0, 0, int_doverbose, 1 },
 	{ "editing",	editinghelp,				CMPL0 0, 0, int_doediting, 1 },
+	{ "!",		shellhelp,				CMPL0 0, 0, int_shell, 0 },
         { "?",		"Options",				CMPL0 0, 0, int_help, 0 },
 	{ "manual",	manhelp,				CMPL(H) (char **)mantab, sizeof(struct ghs), int_manual, 0 },
         { "help",	0,					CMPL0 0, 0, int_help, 0 },
@@ -718,6 +721,7 @@ struct intlist Bridgelist[] = {
 	{ "who",	whohelp,				CMPL0 0, 0, int_who, 0 },
 	{ "verbose",	verbosehelp,				CMPL0 0, 0, int_doverbose, 1 },
 	{ "editing",	editinghelp,				CMPL0 0, 0, int_doediting, 1 },
+	{ "!",		shellhelp,				CMPL0 0, 0, int_shell, 0 },
 
 /* Help commands */
 	{ "?",		"Options",				CMPL0 0, 0, int_help, 0 },
@@ -1072,6 +1076,13 @@ static int
 int_manual(char *ifname, int ifs, int argc, char **argv)
 {
 	manual(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_shell(char *ifname, int ifs, int argc, char **argv)
+{
+	shell(argc, argv);
 	return 0; /* do not leave interface context */
 }
 

--- a/commands.c
+++ b/commands.c
@@ -123,6 +123,8 @@ static int	int_traceroute6(char *, int, int, char **);
 static int	int_ssh(char *, int, int, char **);
 static int	int_telnet(char *, int, int, char **);
 static int	int_show(char *, int, int, char **);
+static int	int_doverbose(char *, int, int, char **);
+static int	int_doediting(char *, int, int, char **);
 static int	int_manual(char *, int, int, char **);
 static int	int_help(void);
 static int	int_exit(void);
@@ -568,6 +570,8 @@ static char tracert6help[];
 static char sshhelp[];
 static char telnethelp[];
 static char showhelp[];
+static char verbosehelp[];
+static char editinghelp[];
 static char manhelp[];
 struct ghs mantab[];
 
@@ -661,6 +665,8 @@ struct intlist Intlist[] = {
 	{ "trunkproto",	"Define trunkproto",			CMPL0 0, 0, inttrunkproto, 1 },
 	{ "shutdown",   "Shutdown interface",			CMPL0 0, 0, intflags, 1 },
 	{ "show",	showhelp,				CMPL(ta) (char **)showlist, sizeof(Menu), int_show, 0 },
+	{ "verbose",	verbosehelp,				CMPL0 0, 0, int_doverbose, 1 },
+	{ "editing",	editinghelp,				CMPL0 0, 0, int_doediting, 1 },
         { "?",		"Options",				CMPL0 0, 0, int_help, 0 },
 	{ "manual",	manhelp,				CMPL(H) (char **)mantab, sizeof(struct ghs), int_manual, 0 },
         { "help",	0,					CMPL0 0, 0, int_help, 0 },
@@ -706,6 +712,8 @@ struct intlist Bridgelist[] = {
 	{ "protect",	"Configure protected bridge domains",	CMPL0 0, 0, brprotect, 1 },
 	{ "shutdown",	"Shutdown bridge",			CMPL0 0, 0, intflags, 1 },
 	{ "show",	showhelp,				CMPL(ta) (char **)showlist, sizeof(Menu), int_show, 0 },
+	{ "verbose",	verbosehelp,				CMPL0 0, 0, int_doverbose, 1 },
+	{ "editing",	editinghelp,				CMPL0 0, 0, int_doediting, 1 },
 
 /* Help commands */
 	{ "?",		"Options",				CMPL0 0, 0, int_help, 0 },
@@ -1032,6 +1040,20 @@ static int
 int_show(char *ifname, int ifs, int argc, char **argv)
 {
 	showcmd(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_doverbose(char *ifname, int ifs, int argc, char **argv)
+{
+	doverbose(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_doediting(char *ifname, int ifs, int argc, char **argv)
+{
+	doediting(argc, argv);
 	return 0; /* do not leave interface context */
 }
 

--- a/commands.c
+++ b/commands.c
@@ -116,6 +116,8 @@ static int	flush_ndp_cache(void);
 static int	flush_history(void);
 static int	is_bad_input(const char *, size_t);
 static int	read_command_line(EditLine *, History *);
+static int	int_ping(char *, int, int, char **);
+static int	int_ping6(char *, int, int, char **);
 static int	int_show(char *, int, int, char **);
 static int	int_manual(char *, int, int, char **);
 static int	int_help(void);
@@ -555,6 +557,8 @@ flush_help(void)
  * Data structures and routines for the interface configuration mode
  */
 
+static char pinghelp[];
+static char ping6help[];
 static char showhelp[];
 static char manhelp[];
 struct ghs mantab[];
@@ -604,6 +608,8 @@ struct intlist Intlist[] = {
 	{ "vnetflowid",	"Use part of vnetid as flowid",		CMPL0 0, 0, intvnetflowid, 1 },
 	{ "parent",	"Parent interface",			CMPL(i) 0, 0, intparent, 1 },
 	{ "patch",	"Pair interface",			CMPL(i) 0, 0, intpatch, 1 },
+	{ "ping",	pinghelp,				CMPL0 0, 0, int_ping, 0 },
+	{ "ping6",	ping6help,				CMPL0 0, 0, int_ping6, 0 },
 	{ "keepalive",	"GRE tunnel keepalive",			CMPL0 0, 0, intkeepalive, 1},
 	{ "mplslabel",	"MPLS local label",			CMPL0 0, 0, intmpls, 1 },
 	{ "pwe",	"MPLS PWE3",				CMPL0 0, 0, intpwe3, 1 },
@@ -669,6 +675,8 @@ struct intlist Bridgelist[] = {
 	{ "fwddelay",	"Time before bridge begins forwarding packets",		CMPL0 0, 0, brval, 1 },
 	{ "hellotime",	"802.1D configuration packet broadcast interval",	CMPL0 0, 0, brval, 1 },
 	{ "priority",	"Spanning priority for all members on an 802.1D bridge",CMPL0 0, 0, brval, 1},
+	{ "ping",	pinghelp,				CMPL0 0, 0, int_ping, 0 },
+	{ "ping6",	ping6help,				CMPL0 0, 0, int_ping6, 0 },
 	{ "rule",	"Bridge layer 2 filtering rules",	CMPL0 0, 0, brrule, 0 },
 	{ "static",	"Static bridge address entry",		CMPL0 0, 0, brstatic, 1 },
 	{ "ifpriority",	"Spanning priority of a member on an 802.1D bridge",	CMPL0 0, 0, brpri, 1 },
@@ -960,6 +968,20 @@ interface(int argc, char **argv, char *modhvar)
 
 	close(ifs);
 	return(0);
+}
+
+static int
+int_ping(char *ifname, int ifs, int argc, char **argv)
+{
+	ping(argc, argv);
+	return 0; /* do not leave interface context */
+}
+
+static int
+int_ping6(char *ifname, int ifs, int argc, char **argv)
+{
+	ping6(argc, argv);
+	return 0; /* do not leave interface context */
 }
 
 static int


### PR DESCRIPTION
Make various diagnostic commands available in interface and bridge command contexts.
This improves usability.