### PR TITLE
Codechecker deadstore var cleanup

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -1045,7 +1045,7 @@ void conf_pwe3(FILE *output, int ifs, char *ifname)
 
 void conf_tunnel(FILE *output, int ifs, char *ifname)
 {
-	int dstport, physrtable, physdf, physecn;
+	int dstport, physrtable;
 	char tmpa[IPSIZ], tmpb[IPSIZ];
 
 	if ((dstport=
@@ -1057,9 +1057,9 @@ void conf_tunnel(FILE *output, int ifs, char *ifname)
 			fprintf(output, ":%i", dstport);
 		if ((physttl = get_physttl(ifs, ifname)) > 0)
 			fprintf(output, " ttl %i", physttl);
-		if ((physecn = get_physecn(ifs, ifname)) > 0)
+		if ((get_physecn(ifs, ifname)) > 0)
 			fprintf(output, " ecn");
-		if ((physdf = get_physdf(ifs, ifname)) > 0)
+		if ((get_physdf(ifs, ifname)) > 0)
 			fprintf(output, " df");	
 		fprintf(output, "\n");
 	}
@@ -1143,22 +1143,22 @@ void conf_brcfg(FILE *output, int ifs, struct if_nameindex *ifn_list,
 
 	if ((l_tmp = bridge_cfg(ifs, ifname, PRIORITY))
 	    != -1 && l_tmp != DEFAULT_PRIORITY)
-		fprintf(output, " priority %lu\n", l_tmp);
+		fprintf(output, " priority %ld\n", l_tmp);
 	if ((l_tmp = bridge_cfg(ifs, ifname, HELLOTIME))
 	    != -1 && l_tmp != DEFAULT_HELLOTIME)
-		fprintf(output, " hellotime %lu\n", l_tmp);
+		fprintf(output, " hellotime %ld\n", l_tmp);
 	if ((l_tmp = bridge_cfg(ifs, ifname, FWDDELAY))
 	    != -1 && l_tmp != DEFAULT_FWDDELAY)
-		fprintf(output, " fwddelay %lu\n", l_tmp);
+		fprintf(output, " fwddelay %ld\n", l_tmp);
 	if ((l_tmp = bridge_cfg(ifs, ifname, MAXAGE))
 	    != -1 && l_tmp != DEFAULT_MAXAGE)
-		fprintf(output, " maxage %lu\n", l_tmp);
+		fprintf(output, " maxage %ld\n", l_tmp);
 	if ((l_tmp = bridge_cfg(ifs, ifname, MAXADDR))
 	    != -1 && l_tmp != DEFAULT_MAXADDR)
-		fprintf(output, " maxaddr %lu\n", l_tmp);
+		fprintf(output, " maxaddr %ld\n", l_tmp);
 	if ((l_tmp = bridge_cfg(ifs, ifname, TIMEOUT))
 	    != -1 && l_tmp != DEFAULT_TIMEOUT)
-		fprintf(output, " timeout %lu\n", l_tmp);
+		fprintf(output, " timeout %ld\n", l_tmp);
 
 	if (bridge_list(ifs, ifname, NULL, tmp_str, TMPSIZ, MEMBER))
 		fprintf(output, " member %s\n", tmp_str);

--- a/if.c
+++ b/if.c
@@ -516,7 +516,7 @@ show_int(int argc, char **argv)
 		printf("  SSID %s", tmp_str);
 		if(get_nwinfo(ifname, tmp_str, sizeof(tmp_str), NWKEY) != 0)
 			printf(", key %s", tmp_str);
-		if ((tmp = get_nwinfo(ifname, tmp_str, sizeof(tmp_str),
+		if ((get_nwinfo(ifname, tmp_str, sizeof(tmp_str),
 		    POWERSAVE)) != 0)
 			printf(", powersaving (%s ms)\n", tmp_str);
 		printf("\n");

--- a/kroute.c
+++ b/kroute.c
@@ -691,7 +691,6 @@ rtmsg(cmd, flags, proxy, export, tableid)
 {
 	static int seq;
 	struct rt_msghdr *rtm;
-	int rlen;
 	char *cp = m_rtmsg.m_space;
 	int l, s;
 
@@ -740,7 +739,7 @@ rtmsg(cmd, flags, proxy, export, tableid)
 	if (verbose)
 		print_rtmsg(rtm);
 
-	if ((rlen = write(s, (char *)&m_rtmsg, l)) < 0) {
+	if ((write(s, (char *)&m_rtmsg, l)) < 0) {
 		/* on a write, the calling function will notify user of error */
 		close(s);
 		return (-1);

--- a/main.c
+++ b/main.c
@@ -80,7 +80,7 @@ main(int argc, char *argv[])
 		}
 
 	argc -= optind;
-	argv += optind;
+	
 
 	if (cflag && iflag)
 		usage();

--- a/main.c
+++ b/main.c
@@ -80,7 +80,8 @@ main(int argc, char *argv[])
 		}
 
 	argc -= optind;
-
+	argv += optind;
+	
 	if (cflag && iflag)
 		usage();
 	if (argc > 0)

--- a/main.c
+++ b/main.c
@@ -81,7 +81,6 @@ main(int argc, char *argv[])
 
 	argc -= optind;
 	argv += optind;
-	
 	if (cflag && iflag)
 		usage();
 	if (argc > 0)

--- a/main.c
+++ b/main.c
@@ -80,7 +80,6 @@ main(int argc, char *argv[])
 		}
 
 	argc -= optind;
-	
 
 	if (cflag && iflag)
 		usage();

--- a/ndp.c
+++ b/ndp.c
@@ -593,7 +593,6 @@ int
 rtmsg_ndp(int cmd)
 {
 	static int seq;
-	int rlen;
 	struct rt_msghdr *rtm = &m_rtmsg.m_rtm;
 	char *cp = m_rtmsg.m_space;
 	int l;
@@ -661,7 +660,7 @@ doit:
 	l = rtm->rtm_msglen;
 	rtm->rtm_seq = ++seq;
 	rtm->rtm_type = cmd;
-	if ((rlen = write(rtsock, (char *)&m_rtmsg, l)) == -1) {
+	if ((write(rtsock, (char *)&m_rtmsg, l)) == -1) {
 		if (errno != ESRCH || cmd != RTM_DELETE) {
 			printf("%% rtmsg_ndp: writing to routing socket: %s\n",
 			    strerror(errno));


### PR DESCRIPTION
clean up variables that are assigned a value but never read  per codechecker 
and confirmed by Chris 