### PR TITLE
show an error message if setting a sysctl fails

### DIFF
--- a/sysctl.c
+++ b/sysctl.c
@@ -86,7 +86,9 @@ sysctl_int(int mib[], int val, int read)
 			break;
 
 	if (sysctl(mib, i, &old, &len, valp, sizeof(int)) == -1) {
-		if (read && errno != ENOPROTOOPT) {
+		if (!read) {
+			printf("%% sysctl_int: sysctl: %s\n", strerror(errno));
+		} else if (errno != ENOPROTOOPT) {
 			printf("%% sysctl_int: sysctl: %s\n", strerror(errno));
 			for (i = 0; i < 6; i++) {
 		                if (mib[i] == MIB_STOP)


### PR DESCRIPTION
This command now displays an error, as expected since modifying the sourceroute option requires securelevel 0:

nsh.my.domain(config-p)/ip sourceroute 1
% sysctl_int: sysctl: Operation not permitted
nsh.my.domain(config-p)/