### PR TITLE
add show diff-config command

### DIFF
--- a/externs.h
+++ b/externs.h
@@ -146,6 +146,7 @@ extern char metricnames[];
 #define TELNET		"/usr/bin/telnet"
 #define SSH		"/usr/bin/ssh"
 #define PKILL		"/usr/bin/pkill"
+#define DIFF		"/usr/bin/diff"
 #define SAVESCRIPT	"/usr/local/bin/save.sh"
 #ifndef DHCPLEASES
 #define DHCPLEASES	"/var/db/dhcpd.leases"

--- a/nsh.8
+++ b/nsh.8
@@ -2581,17 +2581,21 @@ kernel: OpenBSD 7.1 (GENERIC.MP) #459: Mon Apr  4 18:16:13 MDT 2022
 Display the current running configuration on the system, including
 interface and bridge configurations, routes, the system hostname, firewall
 rules, and other information compiled by
-.Nm
-.
+.Nm .
 .Pp
 .Ic show startup-config
 .Pp
 Display the startup configuration on the system, read from nshrc,
 including interface and bridge configuration, routes, the system hostname,
 firewall rules, and other information compiled by
-.Nm
-.
-TBC
+.Nm .
+.Pp
+.Ic show diff-config
+.Pp
+Display differences between the startup configuration and the running
+configuration.
+This command requires root user privileges.
+.Pp
 .Tg flush
 .Ic flush
 .Op routes | arp | ndp | line | bridge-dyn | bridge-all | bridge-rule | pf | history |\&? | help


### PR DESCRIPTION
The show diff-config command displays differences between the startup configuration and the running configuration.

Some information saved in the startup config, such as the public keys of wireguard peers, are not exposed to non-root users by the kernel. Relevant lines will not appear when regular users run 'show running-config'. This results in spurious differences where relevant lines appear in the diff as if they had been deleted from the running configuration. The displayed diff is wrong and misleading, and leaks information which the kernel attempts to hide from non-root users. The 'show diff-config' command is restricted to the root user for this reason. (At present, the default file permissions of /etc/nshrc and the 'show startup-config' command are likewise leaking such info and should probably be restricted to the root user, too.)