### PR TITLE
remove unused arguments of complete() function

### DIFF
--- a/complete.c
+++ b/complete.c
@@ -49,7 +49,7 @@
 #define ttyout stdout
 #define ttyin stdin
 
-unsigned char complete(EditLine *, int, char **, size_t, char *);
+unsigned char complete(EditLine *, char **, size_t);
 
 static int	     comparstr(const void *, const void *);
 static unsigned char complete_ambiguous(char *, int, StringList *, EditLine *);
@@ -336,14 +336,13 @@ exit_i(EditLine *el, int ch)
 unsigned char
 complt_i(EditLine *el, int ch)
 {
-	return(complete(el, ch, (char **)whichlist, sizeof(struct intlist),
-	    NULL));
+	return(complete(el, (char **)whichlist, sizeof(struct intlist)));
 }
 
 unsigned char
 complt_c(EditLine *el, int ch)
 {
-	return(complete(el, ch, (char **)cmdtab, sizeof(struct cmd), NULL));
+	return(complete(el, (char **)cmdtab, sizeof(struct cmd)));
 }
 
 unsigned char
@@ -526,7 +525,7 @@ done:
  * Generic complete routine
  */
 unsigned char
-complete(EditLine *el, int ch, char **table, size_t stlen, char *arg)
+complete(EditLine *el, char **table, size_t stlen)
 {
 	static char word[256];
 	static int lastc_argc, lastc_argo;
@@ -535,7 +534,6 @@ complete(EditLine *el, int ch, char **table, size_t stlen, char *arg)
 	int celems, dolist, level, i;
 	size_t len;
 
-	(void)ch;	/* not used */
 	lf = el_line(el);
 	len = lf->lastchar - lf->buffer;
 	if (len >= sizeof(line))
@@ -569,15 +567,12 @@ complete(EditLine *el, int ch, char **table, size_t stlen, char *arg)
 	if (cursor_argc == 0)
 		return (complete_command(word, dolist, el, table, stlen));
 
-	if (arg == NULL)
-		arg = margv[0];
-
 	if (NO_ARG(margv[0]) && table == (char **)whichlist) {
 		return(complete_noint(word, dolist, el, table, stlen,
 		    cursor_argc - 1));
 	}
 
-	c = (struct ghs *) genget(arg, table, stlen);
+	c = (struct ghs *) genget(margv[0], table, stlen);
 	if (c == (struct ghs *)-1 || c == 0 || Ambiguous(c))
 		return (CC_ERROR);
 


### PR DESCRIPTION
All callers were passing NULL for the final 'arg' argument which was hence always set to margv[0].

The 'ch' argument is unused and is only required for complt_i() and complt_c() which are our hooks into the editline library.