### PR TITLE
remove support for 'continuation' completes from complete()

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1699,11 +1699,11 @@ Command cmdtab[] = {
 	{ "no",		0,		CMPL(c) 0, 0, nocmd,		0, 0, 0, 0 },
 	{ "do",		dohelp,		CMPL(c) 0, 0, docmd,		0, 0, 0, 0 },
 	{ "!",		shellhelp,	CMPL0 0, 0, shell,		1, 0, 0, 0 },
-	{ "?",		helphelp,	CMPL(C) 0, 0, help,		0, 0, 0, 0 },
+	{ "?",		helphelp,	CMPL(c) 0, 0, help,		0, 0, 0, 0 },
 	{ "manual",	manhelp,	CMPL(H) (char **)mantab, sizeof(struct ghs), manual,0, 0, 0, 0 },
 	{ "exit",	exithelp,	CMPL0 0, 0, exitconfig,		1, 0, 0, 0 },
 	{ "quit",	quithelp,	CMPL0 0, 0, quit,		0, 0, 0, 0 },
-	{ "help",	0,		CMPL(C) 0, 0, help,		0, 0, 0, 0 },
+	{ "help",	0,		CMPL(c) 0, 0, help,		0, 0, 0, 0 },
 	{ 0,		0,		CMPL0 0, 0, 0,			0, 0, 0, 0 }
 };
 

--- a/complete.c
+++ b/complete.c
@@ -28,7 +28,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ctype.h>
 #include <err.h>
 #include <errno.h>
 #include <dirent.h>
@@ -588,11 +587,6 @@ complete(EditLine *el, int ch, char **table, size_t stlen, char *arg)
 		return(complete_nocmd(c, word, dolist, el, table, stlen, -1));
 
 	celems = strlen(c->complete);
-
-	/* check for 'continuation' completes (which are uppercase) */
-	if ((cursor_argc > celems) && (celems > 0)
-	    && isupper((unsigned char)c->complete[celems-1]))
-		cursor_argc = celems;
 
 	if (cursor_argc > celems)
 		return (CC_ERROR);


### PR DESCRIPTION
This feature triggered when upper-case characters were given to the CMPL() macro. Its apparent purpose was to keep listing the same list of completions regardless of the current argument position in the command line.
nsh was using this feature only for the '?' and 'help' commands, such that all of the following commands would provide help output:

  help TAB
  help foo TAB
  help foo foo TAB
  help foo foo foo TAB
  etc.

With this change only the first argument to 'help' gets completed, which is consistent with how all other nsh commands behave:

  help TAB

The intended purpose of above 'continuation' completions is unclear to me.

The help completion routines interpret upper/lower case for a different purpose: CMPL(H) results in a vertical display, while CMPL(h) results in a line-by-line display. I added that functionaliy before I learned about 'continuation' completions.

I would rather get rid of this virtually unused feature of the completion subsystem, as part of an effort to simplify the completion routines for future work (such as a 'tcpdump' command which will need more complicated completion logic than we have now).