### PR TITLE
display the output of 'show interface' via the pager

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -1201,7 +1201,8 @@ bridge_addaddr(int s, char *brdg, char *ifname, char *addr)
 }
 
 int
-bridge_addrs(int s, char *brdg, char *hdr_delim, char *body_delim)
+bridge_addrs(int s, char *brdg, char *hdr_delim, char *body_delim,
+    FILE *outfile)
 {
 	struct ifbaconf ifbac;
 	struct ifbareq *ifba;
@@ -1231,17 +1232,18 @@ bridge_addrs(int s, char *brdg, char *hdr_delim, char *body_delim)
 		len *= 2;
 	}
 	if (ifbac.ifbac_len / sizeof(*ifba)) {
-		printf("%sLearned addresses:\n", hdr_delim);
-		printf("%saddress           member age\n", body_delim);
+		fprintf(outfile, "%sLearned addresses:\n", hdr_delim);
+		fprintf(outfile, "%saddress           member age\n",
+		    body_delim);
 	}
 
 	for (i = 0; i < ifbac.ifbac_len / sizeof(*ifba); i++) {
 		ifba = ifbac.ifbac_req + i;
 		strlcpy(buf, ifba->ifba_ifsname, sizeof(buf));
-		printf("%s%s %-6s %u ", body_delim, ether_ntoa(&ifba->ifba_dst),
-		    buf, ifba->ifba_age);
-		bprintf(stdout, ifba->ifba_flags, IFBAFBITS);
-		printf("\n");
+		fprintf(outfile, "%s%s %-6s %u ", body_delim,
+		    ether_ntoa(&ifba->ifba_dst), buf, ifba->ifba_age);
+		bprintf(outfile, ifba->ifba_flags, IFBAFBITS);
+		fputc('\n', outfile);
 	}
 	free(inbuf);
 	return (0);

--- a/carp.c
+++ b/carp.c
@@ -371,7 +371,7 @@ conf_carp(FILE *output, int s, char *ifname)
 }
 
 int
-carp_state(int s, char *ifname)
+carp_state(int s, char *ifname, FILE *outfile)
 {
 	struct ifreq ifr;
 	struct carpreq creq;
@@ -387,16 +387,17 @@ carp_state(int s, char *ifname)
 		return (0);
 
 	if (creq.carpr_balancing <= CARP_BAL_MAXID) {
-		printf("  CARP balancing mode %s", carp_bal_modes[creq.carpr_balancing]);
+		fprintf(outfile, "  CARP balancing mode %s",
+		    carp_bal_modes[creq.carpr_balancing]);
 		pntd = 1;
 	}
 
 	if (creq.carpr_peer.s_addr != htonl(INADDR_CARP_GROUP)) {
-		printf(" peer %s", inet_ntoa(creq.carpr_peer));
+		fprintf(outfile, " peer %s", inet_ntoa(creq.carpr_peer));
 		pntd = 1;
 	}
 	if (pntd)
-		printf("\n");
+		fputc('\n', outfile);
 
 	if (creq.carpr_vhids[0] == 0)
 		return(0);
@@ -405,20 +406,21 @@ carp_state(int s, char *ifname)
 		if (creq.carpr_states[i] <= CARP_MAXSTATE)
 			state = carp_states[creq.carpr_states[i]];
 		if (creq.carpr_vhids[1] == 0) {
-			printf("  CARP state %s, device %s vhid %u advbase %d "
-		 	    "advskew %u\n", state,
+			fprintf(outfile, "  CARP state %s, "
+			    "device %s vhid %u advbase %d advskew %u\n", state,
 			    creq.carpr_carpdev[0] != '\0' ?
 			    creq.carpr_carpdev : "none", creq.carpr_vhids[0],
 			    creq.carpr_advbase, creq.carpr_advskews[0]);
 		} else {
 			if (i == 0) {
-				printf("  CARP device %s advbase %d\n",
+				fprintf(outfile,
+				    "  CARP device %s advbase %d\n",
 				    creq.carpr_carpdev[0] != '\0' ?
 				    creq.carpr_carpdev : "none",
 				    creq.carpr_advbase);
 			}
-			printf("  CARP state %s vhid %u advskew %u\n", state,
-			    creq.carpr_vhids[i], creq.carpr_advskews[i]);
+			fprintf(outfile, "  CARP state %s vhid %u advskew %u\n",
+			    state, creq.carpr_vhids[i], creq.carpr_advskews[i]);
 		}
 	}
 

--- a/externs.h
+++ b/externs.h
@@ -294,7 +294,7 @@ int parse_ipv6(char *, struct in6_addr *);
 #define DEFAULT_LLPRIORITY 3
 void imr_init(char *);
 int is_valid_ifname(char *);
-int show_int(int, char **);
+int show_int(int, char **, FILE *);
 int show_vlans(int, char **);
 int show_ip(int, char **);
 int show_autoconf(int, char **);
@@ -354,7 +354,7 @@ int bridge_confaddrs(int, char *, char *, FILE *);
 int bridge_rules(int, char *, char *, char *, FILE *);
 int bridge_list(int, char *, char *, char *, int, int);
 int bridge_member_search(int, char *);
-int bridge_addrs(int, char *, char *, char *);
+int bridge_addrs(int, char *, char *, char *, FILE *);
 int set_ifflag(int, char *, short);
 int clr_ifflag(int, char *, short);
 int is_bridge(int, char *);
@@ -380,8 +380,8 @@ int64_t get_vnetid(int, char *);
 
 /* media.c */
 #define DEFAULT_MEDIA_TYPE	"autoselect"
-void media_status(int, char *, char *);
-void media_supported(int, char *, char *, char *);
+int media_status(int, char *, char *, FILE *);
+void media_supported(int, char *, char *, char *, FILE *);
 int phys_status(int, char *, char *, char *, int, int);
 int intmedia(char *, int, int, char **);
 int intmediaopt(char *, int, int, char **);
@@ -415,7 +415,7 @@ int intcarp(char *, int, int, char **);
 int intcpass(char *, int, int, char **);
 int intcnode(char *, int, int, char **);
 int conf_carp(FILE *, int, char *);
-int carp_state(int, char *);
+int carp_state(int, char *, FILE *);
 int intcdev(char *, int, int, char **);
 void carplock(int);
 
@@ -423,7 +423,7 @@ void carplock(int);
 int inttrunkport(char *, int, int, char **);
 int inttrunkproto(char *, int, int, char **);
 int conf_trunk(FILE *output, int ifs, char *ifname);
-void show_trunk(int ifs, char *ifname);
+void show_trunk(int ifs, char *ifname, FILE *);
 
 /* who.c */
 int who(int, char **);
@@ -516,9 +516,9 @@ int pflow_status(int, int, char *, char *);
 int intwg(char *, int, int, char **);
 int intwgpeer(char *, int, int, char **);
 void conf_wg(FILE *, int, char *);
-void show_wg(int, char *);
+void show_wg(int, char *, FILE *);
 
 /* umb.c */
 int intumb(char *, int, int, char **);
 void conf_umb(FILE *, int, char *);
-void show_umb(int, char *);
+void show_umb(int, char *, FILE *);

--- a/trunk.c
+++ b/trunk.c
@@ -195,7 +195,8 @@ conf_trunk(FILE *output, int ifs, char *ifname)
 
                 for (i = 0; i < ra.ra_ports; ++i)
 			if(rpbuf[i].rp_portname[0] != '\0') {
-				fprintf(output, " %s%s", pntd ? "" : "trunkport ",
+				fprintf(output, " %s%s",
+				    pntd ? "" : "trunkport ",
 				    rpbuf[i].rp_portname);
 				pntd = 1;
 			}
@@ -208,7 +209,7 @@ conf_trunk(FILE *output, int ifs, char *ifname)
 }
 
 void
-show_trunk(int ifs, char *ifname)
+show_trunk(int ifs, char *ifname, FILE *outfile)
 {
 	struct trunk_reqport rp, rpbuf[TRUNK_MAX_PORTS];
 	struct trunk_reqall ra;
@@ -220,9 +221,9 @@ show_trunk(int ifs, char *ifname)
 	strlcpy(rp.rp_portname, ifname, sizeof(rp.rp_portname));
 
 	if (ioctl(ifs, SIOCGTRUNKPORT, (caddr_t)&rp) == 0) {
-		printf("  Trunk parent %s ", rp.rp_ifname);
-		bprintf(stdout, rp.rp_flags, TRUNK_PORT_BITS);
-		printf("\n");
+		fprintf(outfile, "  Trunk parent %s ", rp.rp_ifname);
+		bprintf(outfile, rp.rp_flags, TRUNK_PORT_BITS);
+		fputc('\n', outfile);
 	}
 
 	for (i = 0; i < TRUNK_MAX_PORTS; i++)
@@ -237,18 +238,20 @@ show_trunk(int ifs, char *ifname)
 
 		for (i = 0; i < TRUNK_PROTO_MAX; i++)
 			if (ra.ra_proto == tpr[i].tpr_proto) {
-				printf("  Trunkproto %s", tpr[i].tpr_name);
+				fprintf(outfile, "  Trunkproto %s",
+				    tpr[i].tpr_name);
 				pntd = 1;
 				break;
 			}
 		for (i = 0; i < ra.ra_ports; i++)
 			if(rpbuf[i].rp_portname[0] != '\0') {
-				printf(" (%s ", rpbuf[i].rp_portname);
-				bprintf(stdout, rpbuf[i].rp_flags, TRUNK_PORT_BITS);
-				printf(")");
+				fprintf(outfile, " (%s ", rpbuf[i].rp_portname);
+				bprintf(outfile, rpbuf[i].rp_flags,
+				    TRUNK_PORT_BITS);
+				putc(')', outfile);
 				pntd = 1;
 			}
 		if (pntd)
-			printf("\n");
+			fputc('\n', outfile);
 	}
 }

--- a/wg.c
+++ b/wg.c
@@ -296,7 +296,7 @@ getwg(int ifs)
 }
 
 void
-show_wg(int ifs, char *ifname)
+show_wg(int ifs, char *ifname, FILE *outfile)
 {
 	int			 i;
 	struct timespec		 now;
@@ -313,21 +313,21 @@ show_wg(int ifs, char *ifname)
 	if (wg_interface->i_flags & WG_INTERFACE_HAS_PUBLIC) {
 		b64_ntop(wg_interface->i_public, WG_KEY_LEN,
 		    key, sizeof(key));
-		printf("  Wireguard publickey %s\n", key);
+		fprintf(outfile, "  Wireguard publickey %s\n", key);
 	}
 
 	wg_peer = &wg_interface->i_peers[0];
 	for (i = 0; i < wg_interface->i_peers_count; i++) {
 		b64_ntop(wg_peer->p_public, WG_KEY_LEN,
 		    key, sizeof(key));
-		printf("  Wireguard peer %s", key);
+		fprintf(outfile, "  Wireguard peer %s", key);
 
 		if (wg_peer->p_last_handshake.tv_sec != 0) {
 			timespec_get(&now, TIME_UTC);
-			printf(" last handshake: %lld seconds ago\n",
+			fprintf(outfile, " last handshake: %lld seconds ago\n",
 			    now.tv_sec - wg_peer->p_last_handshake.tv_sec);
 		}
-		printf("\n");
+		putc('\n', outfile);
 	}
 	free(wgdata.wgd_interface);
 }


### PR DESCRIPTION
The output of 'show interface' can be very long so use of a pager seems appropriate. Unfortunately, this requires changes across many routines inherited from ifconfig which were hard-coded to write to stdout. This commit changes such prints to write to a temporary file instead, and hopefully I caught them all.

For now, error messages still go to standard output. In some cases the propagation of error return codes is inconsistent and won't allow callers to know whether an error occurred. This should be fixed first. I did consider writing all errors to the temporary file as part of regular output but I am undecided whether this is the best approach. If nsh ever becomes a multi-process program we will likely want errors to appear on a dedicated channel.