### PR TITLE
make the reboot and halt commands safer to use

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -69,6 +69,7 @@
 #include "ctl.h"
 
 char prompt[128];
+char saved_prompt[sizeof(prompt)];
 
 char line[1024];
 char saveline[1024];
@@ -2893,6 +2894,25 @@ iprompt(void)
 	return(prompt);
 }
 
+char *
+pprompt(void)
+{
+	return(prompt);
+}
+
+static void
+setprompt(const char *s)
+{
+	strlcpy(saved_prompt, prompt, sizeof(saved_prompt));
+	strlcpy(prompt, s, sizeof(prompt));
+}
+
+static void
+restoreprompt(void)
+{
+	strlcpy(prompt, saved_prompt, sizeof(prompt));
+}
+
 int
 wr_startup(void)
 {
@@ -2929,25 +2949,155 @@ wr_conf(char *fname)
 	return (success);
 }
 
+static int
+conf_has_unsaved_changes(void)
+{
+	int conf_fd = -1, nshrc_fd = -1;
+	char confpath[PATH_MAX];
+	char buf1[8192];
+	char buf2[8192];
+	int ret = -1;
+
+	if (priv != 1) {
+		printf("%% Privilege required\n");
+		return -1;
+	}
+
+	if (getuid() != 0) {
+		printf("%% Root privileges required\n");
+		return -1;
+	}
+
+	if (strlcpy(confpath, "/tmp/nshrc.XXXXXXXX", sizeof(confpath)) >=
+	    sizeof(confpath))
+		return -1;
+
+	conf_fd = mkstemp(confpath);
+	if (conf_fd == -1) {
+		printf("%% mkstemp %s: %s\n", confpath, strerror(errno));
+		return -1;
+	}
+
+	if (!wr_conf(confpath)) {
+		printf("%% Couldn't generate configuration\n");
+		goto done;
+	}
+
+	nshrc_fd = open(NSHRC, O_RDONLY);
+	if (nshrc_fd == -1) {
+		printf("%% open %s: %s\n", NSHRC, strerror(errno));
+		goto done;
+	}
+
+	lseek(conf_fd, 0, SEEK_SET);
+
+	for (;;) {
+		ssize_t r1, r2;
+
+		r1 = read(nshrc_fd, buf1, sizeof(buf1));
+		if (r1 == -1) {
+			printf("%% read %s: %s\n", NSHRC, strerror(errno));
+			goto done;
+		}
+
+		r2 = read(conf_fd, buf2, sizeof(buf2));
+		if (r2 == -1) {
+			printf("%% read %s: %s\n", confpath, strerror(errno));
+			goto done;
+		}
+
+		if (r1 == 0 && r2 == 0) {
+			ret = 0;
+			break;
+		} else if (r1 != r2 || memcmp(buf1, buf2, r1) != 0) {
+			ret = 1;
+			break;
+		}
+	}
+done:
+	if (conf_fd != -1) {
+		unlink(confpath);
+		close(conf_fd);
+	}
+	if (nshrc_fd != -1)
+		close(nshrc_fd);
+	return ret;
+}
+
+static int
+do_reboot(int how)
+{
+	const char *buf;
+	int ret = 0, num, have_changes;
+
+	have_changes = conf_has_unsaved_changes();
+	if (have_changes == -1)
+		return -1;
+	else if (have_changes) {
+		printf("%% WARNING: The running configuration contains "
+		    "unsaved changes!\n"
+		    "%% The 'show diff-config' command will display unsaved "
+		    "changes.\n"
+		    "%% The 'write-config' command will save changes to %s.\n",
+		    NSHRC);
+	}
+
+	switch (how) {
+	case RB_AUTOBOOT:
+		setprompt("Proceed with reboot? [yes/no] ");
+		break;
+	case RB_HALT:
+		setprompt("Proceed with shutdown? [yes/no] ");
+		break;
+	default:
+		printf("%% Invalid reboot parameter 0x%x\n", how);
+		return 0;
+	}
+
+	for (;;) {
+		if ((buf = el_gets(elp, &num)) == NULL) {
+			if (num == -1) {
+				ret = -1;
+				goto done;
+			}
+			/* EOF, e.g. ^X or ^D via exit_i() in complete.c */
+			goto done;
+		}
+
+		if (strcasecmp(buf, "yes\n") == 0)
+			break;
+
+		if (strcasecmp(buf, "no\n") == 0)
+			goto done;
+
+		printf("%% Please type \"yes\" or \"no\"\n");
+	}
+
+	if (how == RB_AUTOBOOT)
+		printf("%% Reboot initiated\n");
+	else
+		printf("%% Shutdown initiated\n");
+
+	if (reboot(how) == -1)
+		printf("%% reboot: %s\n", strerror(errno));
+done:
+	restoreprompt();
+	return ret;
+}
+
 /*
  * Reboot
  */
 int
 nreboot(void)
 {
-	printf ("%% Reboot initiated\n");
-	if (reboot (RB_AUTOBOOT) == -1)
-		printf("%% reboot: RB_AUTOBOOT: %s\n", strerror(errno));
-	return(0);
+	return do_reboot(RB_AUTOBOOT);
 }
 
 int
 halt(void)
 {
-	printf ("%% Shutdown initiated\n");
-	if (reboot (RB_HALT) == -1)
-		printf("%% reboot: RB_HALT: %s\n", strerror(errno));
-	return(0);
+	return do_reboot(RB_HALT);
 }
 
 /*

--- a/complete.c
+++ b/complete.c
@@ -985,6 +985,17 @@ initedit()
 		el_source(eli, NULL);
 		el_set(eli, EL_SIGNAL, 1);
 	}
+	if (!elp) {
+		elp = el_init(__progname, stdin, stdout, stderr);
+		el_set(elp, EL_EDITOR, "emacs"); /* default type */
+		el_set(elp, EL_PROMPT, pprompt); /* set the prompt
+						  * function */
+		el_set(eli, EL_ADDFN, "exit_i", "Exit", exit_i);
+		el_set(eli, EL_BIND, "^X", "exit_i", NULL);
+		el_set(eli, EL_BIND, "^D", "exit_i", NULL);
+		el_source(elp, NULL);	/* read ~/.editrc */
+		el_set(elp, EL_SIGNAL, 1);
+	}
 }
 
 void

--- a/editing.h
+++ b/editing.h
@@ -1,7 +1,8 @@
 #include <histedit.h>
 
-extern EditLine *elc;		/* editline(3) status structure */
-extern EditLine *eli;		/* another one */
+extern EditLine *elc;		/* editline(3) status of main command prompt */
+extern EditLine *eli;		/* another one for interface/bridge mode */
+extern EditLine *elp;		/* general-purpose prompt (no completion) */
 extern History *histc;		/* command() editline(3) history structure */
 extern History *histi;		/* interface() editline(3) status structure */
 extern char	*cursor_pos;	/* cursor position we're looking for */

--- a/main.c
+++ b/main.c
@@ -47,6 +47,7 @@ History *histc = NULL;
 HistEvent ev;
 EditLine *elc = NULL;
 EditLine *eli = NULL;
+EditLine *elp = NULL;
 char *cursor_pos = NULL;
 
 void intr(void);

--- a/nsh.8
+++ b/nsh.8
@@ -1663,10 +1663,9 @@ are documented in
 .Ic reboot
 .Pp
 Restart the system.
-Warning no confirmation prompt is issued, configuration changes are
-NOT automatically saved!
-User must save configuration manually BEFORE using reboot.
-Requires privileged access.
+Requires
+.Nm
+to be in privileged mode and requires root user privileges.
 .Bl -dash
 .It
 E.g. restart the system
@@ -1679,10 +1678,9 @@ nsh(config-p)/reboot
 .Tg halt
 .Ic halt
 shut down the system.
-Warning no confirmation prompt is issued, configuration changes are
-NOT automatically saved!
-User must save configuration manually BEFORE using halt.
-Requires privileged mode.
+Requires
+.Nm
+to be in privileged mode and requires root user privileges.
 .Bl -dash
 .It
 e.g. shutdown the system


### PR DESCRIPTION
The reboot and halt commands now ask for explicit confirmation and will warn when unsaved changes are present in the running configuration.