### PR TITLE
call /sbin/reboot instead of reboot(2) to ensure clean reboots

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -152,6 +152,7 @@ static int	telnet(int, char*[]);
        void	p_argv(int, char **);
 static int 	nreboot(void);
 static int 	halt(void);
+static int 	powerdown(void);
 static Command *getcmd(char *);
 static void	pf_stats(void);
 static void	sigalarm(int);
@@ -1520,6 +1521,7 @@ static char
 	savehelp[] =	"Save the current configuration",
 	nreboothelp[] =	"Reboot the system",
 	halthelp[] =	"Halt the system",
+	powerdownhelp[] ="Power the system down",
 	helphelp[] =	"Print help information",
 	manhelp[] =	"Display the NSH manual";
 
@@ -1758,6 +1760,7 @@ Command cmdtab[] = {
 	{ "telnet",	telnethelp,	CMPL0 0, 0, telnet,		0, 0, 0, 0 },
 	{ "reboot",	nreboothelp,	CMPL0 0, 0, nreboot,		1, 0, 0, 0 },
 	{ "halt",	halthelp,	CMPL0 0, 0, halt,		1, 0, 0, 0 },
+	{ "powerdown",	powerdownhelp,	CMPL0 0, 0, powerdown,		1, 0, 0, 0 },
 	{ "write-config", savehelp,	CMPL0 0, 0, wr_startup,		1, 0, 0, 0 },
 	{ "verbose",	verbosehelp,	CMPL0 0, 0, doverbose,		0, 0, 1, 0 },
 	{ "editing",	editinghelp,	CMPL0 0, 0, doediting,		0, 0, 1, 0 },
@@ -3089,6 +3092,7 @@ do_reboot(int how)
 {
 	const char *buf;
 	int ret = 0, num, have_changes;
+	char *argv[3] = { REBOOT, NULL, NULL };
 
 	have_changes = conf_has_unsaved_changes();
 	if (have_changes == -1)
@@ -3107,7 +3111,13 @@ do_reboot(int how)
 		setprompt("Proceed with reboot? [yes/no] ");
 		break;
 	case RB_HALT:
+		argv[0] = HALT;
 		setprompt("Proceed with shutdown? [yes/no] ");
+		break;
+	case RB_POWERDOWN:
+		argv[0] = HALT;
+		argv[1] = "-p";
+		setprompt("Proceed with powerdown? [yes/no] ");
 		break;
 	default:
 		printf("%% Invalid reboot parameter 0x%x\n", how);
@@ -3138,8 +3148,8 @@ do_reboot(int how)
 	else
 		printf("%% Shutdown initiated\n");
 
-	if (reboot(how) == -1)
-		printf("%% reboot: %s\n", strerror(errno));
+	if (cmdargs(argv[0], argv) != 0)
+		printf("%% %s command failed\n", argv[0]);
 done:
 	restoreprompt();
 	return ret;
@@ -3160,6 +3170,11 @@ halt(void)
 	return do_reboot(RB_HALT);
 }
 
+int
+powerdown(void)
+{
+	return do_reboot(RB_POWERDOWN);
+}
 /*
  * Flush wrappers
  */

--- a/externs.h
+++ b/externs.h
@@ -156,6 +156,8 @@ extern char metricnames[];
 #define SSH		"/usr/bin/ssh"
 #define PKILL		"/usr/bin/pkill"
 #define DIFF		"/usr/bin/diff"
+#define REBOOT		"/sbin/reboot"
+#define HALT		"/sbin/halt"
 #define SAVESCRIPT	"/usr/local/bin/save.sh"
 #ifndef DHCPLEASES
 #define DHCPLEASES	"/var/db/dhcpd.leases"

--- a/nsh.8
+++ b/nsh.8
@@ -370,6 +370,7 @@ nsh(p)/help
   telnet        Telnet connection to remote host
   reboot        Reboot the system
   halt          Halt the system
+  powerdown     Power the system down
   write-config  Save the current configuration
   verbose       Set verbose diagnostics
   editing       Set command line editing
@@ -1677,7 +1678,9 @@ nsh(config-p)/reboot
 .Pp
 .Tg halt
 .Ic halt
-shut down the system.
+Shut down the system.
+The system will halt and then wait for a key to be pressed on the
+console before rebooting.
 Requires
 .Nm
 to be in privileged mode and requires root user privileges.
@@ -1686,6 +1689,22 @@ to be in privileged mode and requires root user privileges.
 e.g. shutdown the system
 .Bd -literal -offset indent
 nsh(p)/halt
+% Shutdown initiated
+.Ed
+.El
+.Pp
+.Tg powerdown
+.Ic powerdown
+Shut down the system and then turn off power.
+Restarting the system will require access to the power-on button.
+Requires
+.Nm
+to be in privileged mode and requires root user privileges.
+.Bl -dash
+.It
+e.g. power the system down
+.Bd -literal -offset indent
+nsh(p)/powerdown
 % Shutdown initiated
 .Ed
 .El


### PR DESCRIPTION
Calling the reboot(2) system call directly skips a lot of steps that are performed by the reboot program to ensure that processes are stopped and disks get synced. Testing shows that skipping these steps results in misbehaviour such as SSH sessions towards the nsh system hanging instead of being terminated cleanly by sshd. It can even result in a visit to ddb(4) due to unflushed vnodes hitting a KASSERT during reboot (clearly a kernel-side bug, but anyway it would hurt if triggered in production).

Rather than reimplementing all the logic of the reboot program in nsh just call the reboot binary. This seems like the most robust approach to me.

While here, add a powerdown command which runs halt -p and update the man page to explain the differences between regular halt and halt -p.