### PR TITLE
use more(1) style input keys for the pager

### DIFF
--- a/more.c
+++ b/more.c
@@ -78,16 +78,23 @@ more(char *fname)
 			ws = NULL;
 
 		if (!nopager && i + extra_rows >= (winsize.ws_row - 1)) {
-			printf(PAGERPROMPT);
-			fflush(0);
-			c = getchar();
-			printf(BACKOVERPROMPT);
-			if (c == 'q')
-				break;			/* stop */
-			if (c == '\r' || c == '\n')
-				i--;			/* skip one line */
-			else
-				i = 0;			/* skip one page */
+			for (;;) {
+				printf(PAGERPROMPT);
+				fflush(0);
+				c = getchar();
+				printf(BACKOVERPROMPT);
+				if (c == 'q')
+					goto quit;
+				if (c == '\r' || c == '\n' || c == 'j' ||
+				    c == CTRL('n')) {
+					i--; /* skip one line */
+					break;
+				}
+				if (c == ' ' || c == 'f' || c == CTRL('f')) {
+					i = 0; /* skip one page */
+					break;
+				}
+			}
 		}
 
 		/*
@@ -102,7 +109,7 @@ more(char *fname)
 			printf("%s\n", input);
 		i += extra_rows;
 	}
-
+quit:
 	if (!nopager)
 		nsh_nocbreak();
 


### PR DESCRIPTION
Input keys accepted by the pager do not seem to be documented. Because most people will be used to hitting keys used by more(1) and similar tools we should use the same keys as offered by more(1) to advance to the next line or page.

Enter, j, and Ctrl-n now advance to the next line. Space, f, and Ctrl-f now advance to the next page.

We no longer make unrecognized keys advance to the next page because this makes it harder to discover the set of valid keys by trial-and-error.