### PR TITLE
make the 'enable' command switch to the root user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ PROG= nsh
 DEBUG?=-O0 -g
 .endif
 
+NSH_REXEC_PATH?=/usr/local/bin/nsh
+
 .if make(install)
 DESTDIR?=/usr/local
 BINDIR?=/bin
@@ -19,7 +21,7 @@ MANDIR?=/man/man
 #CFLAGS=-O -DDHCPLEASES=\"/flash/dhcpd.leases\" -Wmissing-prototypes -Wformat -Wall -Wpointer-arith -Wbad-function-cast #-W
 CFLAGS?=-O
 CFLAGS+=-Wmissing-prototypes -Wformat -Wall -Wbad-function-cast -I/usr/local/include #-W -Wpointer-arith
-CPPFLAGS+=-DNSH_VERSION=${NSH_VERSION}
+CPPFLAGS+=-DNSH_VERSION=${NSH_VERSION}  -DNSH_REXEC_PATH=${NSH_REXEC_PATH}
 
 SRCS=arp.c compile.c main.c genget.c commands.c stats.c kroute.c
 SRCS+=ctl.c show.c if.c version.c route.c conf.c complete.c ieee80211.c

--- a/commands.c
+++ b/commands.c
@@ -86,7 +86,6 @@ size_t	cursor_argo;			/* offset of cursor margv[cursor_argc] */
 
 pid_t	child;
 
-static int	quit(void);
 static int	disable(void);
 static int	doverbose(int, char**);
 static int	doediting(int, char**);
@@ -173,8 +172,12 @@ void sigalarm(int blahfart)
 int
 quit(void)
 {
-	printf("%% Session terminated.\n");
-	exit(0);
+	if (privexec) {
+		exit(NSH_REXEC_EXIT_CODE_QUIT);
+	} else {
+		printf("%% Session terminated.\n");
+		exit(0);
+	}
 	return 0;
 }
 
@@ -2606,6 +2609,10 @@ cmdargs_output(char *cmd, char *arg[], int stdoutfd, int stderrfd)
 int
 disable(void)
 {
+	if (privexec) {
+		exit(0);
+		return 0;
+	}
 	priv = 0;
 	config_mode = 0;
 	return 0;

--- a/externs.h
+++ b/externs.h
@@ -6,10 +6,13 @@
 #error "NSH_VERSION is undefined"
 #endif
 
-#define NSH_STRINGIFY_VERSION(x) #x
-#define NSH_STRINGVAL_VERSION(x) NSH_STRINGIFY_VERSION(x)
+#define NSH_STRINGIFY(x) #x
+#define NSH_STRINGVAL(x) NSH_STRINGIFY(x)
 
-#define NSH_VERSION_STR NSH_STRINGVAL_VERSION(NSH_VERSION)
+#define NSH_VERSION_STR NSH_STRINGVAL(NSH_VERSION)
+
+#define NSH_REXEC_PATH_STR		NSH_STRINGVAL(NSH_REXEC_PATH)
+#define NSH_REXEC_EXIT_CODE_QUIT	42
 
 #define NO_ARG(x)	(strcasecmp(x, "no") == 0) /* absolute "no" */
 
@@ -31,6 +34,7 @@ extern int editing;		/* is command line editing mode on? */
 extern int config_mode;		/* are we in comfig mode? */
 extern int bridge;		/* are we in bridge mode (or interface mode?) */
 extern int priv;		/* privileged mode or not? */
+extern int privexec;		/* process was started in privileged mode? */
 extern pid_t pid;		/* process id of nsh */
 extern int cli_rtable;		/* environment rtable */
 
@@ -158,10 +162,13 @@ extern char metricnames[];
 #define DIFF		"/usr/bin/diff"
 #define REBOOT		"/sbin/reboot"
 #define HALT		"/sbin/halt"
+#define SU		"/usr/bin/su"
+#define DOAS		"/usr/bin/doas"
 #define SAVESCRIPT	"/usr/local/bin/save.sh"
 #ifndef DHCPLEASES
 #define DHCPLEASES	"/var/db/dhcpd.leases"
 #endif
+int quit(void);
 void command(void);
 char **step_optreq(char **, char **, int, char **, int);
 int argvtostring(int, char **, char *, int);


### PR DESCRIPTION
Make nsh re-exec itself as root when the 'enable' command is used by a non-root user. Rely on doas(1) or su(1) for authentication to root, once the enable secret, if present, has been entered correctly. A new nsh child process runs as root and starts out in privileged mode while the parent process waits for the child to exit.

A behaviour change is that the 'enable' command will fail if root access cannot be obtained. Either knowledge of the root password or lines in /etc/doas.conf such as the following are needed to enter privileged mode.

  permit keepenv user as root cmd /usr/local/bin/nsh args -e
  permit keepenv :group as root cmd /usr/local/bin/nsh args -e

Of course the above lines essentially allow arbitrary command execution as root because the nsh ! command could be used in privileged mode. We could try to restrict this, but I am not sure if trying to restrict nsh users makes a lot of sense in the current single-process design of nsh.

An absolute path to the installed nsh binary must be known at compile-time because finding the path to the executable which started a program is not possible on OpenBSD (and won't work 100% reliably on other systems either). The default rexec-path is /usr/local/bin/nsh. This default can be changed at compile-time by setting the NSH_REXEC_PATH macro in CFLAGS during the build.

No documentation updates yet as there is already extensive documentation for other approaches to running nsh as root, all of which needs to be re-considered and perhaps deprecated or removed.

The idea to have nsh re-exec itself as root during 'enable' came from claudio@