### PR TITLE
add 'show environment', 'setenv', and 'unsetenv' commands

### DIFF
--- a/nsh.8
+++ b/nsh.8
@@ -2688,6 +2688,41 @@ Display differences between the startup configuration and the running
 configuration.
 This command requires root user privileges.
 .Pp
+.Ic show environment Op Ar NAME
+.Pp
+Display environment variables. 
+If the
+.Ar NAME
+of a variable is specified then display the value of this variable.
+Otherwise, display all existing environment variable names and values.
+.Pp
+.Tg setenv
+.Ic setenv Ar NAME=VALUE
+.Pp
+Set the environment variable
+.Ar NAME
+to the specified
+.Ar VALUE.
+If a
+.Ar NAME
+or
+.Ar VALUE
+contains whitespace then it must be quoted in double-quotes.
+For example:
+.Bd -literal -offset indent
+nsh/setenv EDITOR=/usr/local/bin/emacs
+nsh/setenv MY_VARIABLE="this value contains whitespace"
+nsh/setenv "MY OTHER VARIABLE"=my-name-contains-whitespace
+.Ed
+.Pp
+.Tg unsetenv
+.Pp
+.Ic unsetenv Ar NAME
+.Pp
+Delete the variable
+.Ar NAME
+from the environment.
+.Pp
 .Tg flush
 .Ic flush
 .Op routes | arp | ndp | line | bridge-dyn | bridge-all | bridge-rule | pf | history |\&? | help


### PR DESCRIPTION
Being able to manage environment variables from within nsh will be useful, especially if nsh is used as a login shell because nsh's environment is visible to other commands run by nsh.

Setting variables can now affect the behaviour of nsh itself. For example, it is possible to set NSH_MANUAL_PAGE from within a running nsh session and the new value will immediately be used by the 'manual' command. This particular variable is only useful to nsh developers themselves but the same mechanism could be used for user-facing variables in the future.

If 'show environment' is run without further arguments all variables will be displayed. Otherwise the value of the specified variable will be displayed if the variable exists.

All commands support tab-completion for names which already exist in the environment. The 'setenv' commands appends "=" if the name being completed does not yet exist in the environment.