### PR TITLE
add a runat command and scripting via the nsh command-line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ SRCS+=ctl.c show.c if.c version.c route.c conf.c complete.c ieee80211.c
 SRCS+=bridge.c tunnel.c media.c sysctl.c passwd.c pfsync.c carp.c
 SRCS+=trunk.c who.c more.c stringlist.c utils.c sqlite3.c ppp.c prompt.c
 SRCS+=nopt.c pflow.c wg.c nameserver.c ndp.c umb.c utf8.c cmdargs.c ctlargs.c
-SRCS+=helpcommands.c makeargv.c
+SRCS+=helpcommands.c makeargv.c findprog.c
 CLEANFILES+=compile.c
 LDADD=-lutil -ledit -ltermcap -lsqlite3 -L/usr/local/lib #-static
 

--- a/bgpnsh/bgpnsh.c
+++ b/bgpnsh/bgpnsh.c
@@ -50,7 +50,7 @@ void sigalarm(int signo)
 	}
 }
 
-int editing = 1, config_mode = 0;
+int editing = 1, config_mode = 0, interactive_mode = 1;
 int cli_rtable;
 int bridge;
 size_t Intlist_nitems = 0, Bridgelist_nitems = 0;

--- a/cmdargs.c
+++ b/cmdargs.c
@@ -54,6 +54,13 @@ cmdargs(char *cmd, char *arg[])
 int
 cmdargs_output(char *cmd, char *arg[], int stdoutfd, int stderrfd)
 {
+	return cmdargs_output_setenv(cmd, arg, stdoutfd, stderrfd, NULL);
+}
+
+int
+cmdargs_output_setenv(char *cmd, char *arg[], int stdoutfd, int stderrfd,
+    char **env)
+{
 	sig_t sigint, sigquit, sigchld;
 	int status = -1;
 
@@ -94,8 +101,11 @@ cmdargs_output(char *cmd, char *arg[], int stdoutfd, int stderrfd)
 				}
 			}
 
-			execv(shellp, arg);
-			printf("%% execv failed: %s\n", strerror(errno));
+			if (env)
+				execvpe(shellp, arg, env);
+			else
+				execv(shellp, arg);
+			printf("%% exec failed: %s\n", strerror(errno));
 			_exit(127); /* same as what ksh(1) would do here */
 		}
 			break;

--- a/externs.h
+++ b/externs.h
@@ -32,6 +32,7 @@ extern int  margc;		/* makeargv() arg count */
 extern char *margv[];		/* makeargv() args */
 extern int verbose;		/* is verbose mode on? */
 extern int editing;		/* is command line editing mode on? */
+extern int interactive_mode;	/* are we in interactive mode? */
 extern int config_mode;		/* are we in comfig mode? */
 extern int bridge;		/* are we in bridge mode (or interface mode?) */
 extern int priv;		/* privileged mode or not? */
@@ -149,6 +150,7 @@ extern char metricnames[];
 /* ctl.c declarations moved to ctl.h */
 
 /* cmdargs.c */
+int cmdargs_output_setenv(char *, char **, int, int, char **);
 int cmdargs_output(char *, char **, int, int);
 int cmdargs(char *, char **);
 int nsh_setrtable(int);
@@ -167,6 +169,7 @@ extern pid_t child;
 #define SSH		"/usr/bin/ssh"
 #define PKILL		"/usr/bin/pkill"
 #define DIFF		"/usr/bin/diff"
+#define AT		"/usr/bin/at"
 #define CRONTAB		"/usr/bin/crontab"
 #define REBOOT		"/sbin/reboot"
 #define HALT		"/sbin/halt"
@@ -180,7 +183,7 @@ int quit(void);
 void sigalarm(int);
 void command(void);
 int argvtostring(int, char **, char *, int);
-int cmdrc(char rcname[FILENAME_MAX]);
+int cmdrc(char rcname[FILENAME_MAX], int);
 
 /* prompt.c */
 char *iprompt(void);
@@ -563,3 +566,8 @@ int mbsavis(char**, int *, const char *);
 /* ctlargs.c */
 int pr_prot1(int, char **);
 char **step_optreq(char **, char **, int, char **, int);
+
+/* findprog.c */
+#define PROG_WHICH	1
+#define PROG_WHEREIS	2
+int findprog(char *, char *, int, int);

--- a/findprog.c
+++ b/findprog.c
@@ -1,0 +1,85 @@
+/*	$OpenBSD: which.c,v 1.27 2019/01/25 00:19:27 millert Exp $	*/
+
+/*
+ * Copyright (c) 1997 Todd C. Miller <millert@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/stat.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "externs.h"
+
+int
+findprog(char *prog, char *path, int progmode, int allmatches)
+{
+	char *p, filename[PATH_MAX];
+	int len, rval = 0;
+	struct stat sbuf;
+	char *pathcpy;
+
+	/* Special case if prog contains '/' */
+	if (strchr(prog, '/')) {
+		if ((stat(prog, &sbuf) == 0) && S_ISREG(sbuf.st_mode) &&
+		    access(prog, X_OK) == 0) {
+			return (1);
+		} else {
+			printf("%% %s: Command not found.\n", prog);
+			return (0);
+		}
+	}
+
+	if ((path = strdup(path)) == NULL) {
+		printf("%%: findprog: strdup: %s\n", strerror(errno));
+		return 0;
+	}
+	pathcpy = path;
+
+	while ((p = strsep(&pathcpy, ":")) != NULL) {
+		if (*p == '\0')
+			p = ".";
+
+		len = strlen(p);
+		while (len > 0 && p[len-1] == '/')
+			p[--len] = '\0';	/* strip trailing '/' */
+
+		len = snprintf(filename, sizeof(filename), "%s/%s", p, prog);
+		if (len < 0 || len >= sizeof(filename)) {
+			printf("%% findprog: %s/%s: %s\n", p, prog,
+			    strerror(ENAMETOOLONG));
+			free(path);
+			return (0);
+		}
+		if ((stat(filename, &sbuf) == 0) && S_ISREG(sbuf.st_mode) &&
+		    access(filename, X_OK) == 0) {
+			rval = 1;
+			if (!allmatches) {
+				free(path);
+				return (rval);
+			}
+		}
+	}
+	(void)free(path);
+
+	/* whereis(1) is silent on failure. */
+	if (!rval && progmode != PROG_WHEREIS)
+		printf("%% %s: Command not found.\n", prog);
+	return (rval);
+}

--- a/main.c
+++ b/main.c
@@ -40,7 +40,7 @@ char *vers = NSH_VERSION_STR;
 int bridge = 0;		/* bridge mode for interface() */
 int verbose = 0;	/* verbose mode */
 int priv = 0, privexec = 0, cli_rtable = 0;
-int editing = 1, config_mode = 0;;
+int editing = 0, interactive_mode = 0, config_mode = 0;;
 pid_t pid;
 
 History *histi = NULL;
@@ -89,11 +89,6 @@ main(int argc, char *argv[])
 		}
 
 
-	if (getuid() != 0) {
-		printf("%% Functionality is limited without root privileges.\n"
-		    "%% The 'enable' command will switch to the root user.\n");
-	}
-
 	argc -= optind;
 	argv += optind;
 	if (cflag && iflag)
@@ -103,8 +98,19 @@ main(int argc, char *argv[])
 	if (iflag)
 		rmtemp(SQ3DBFILE);
 
-	if (!privexec)
-		printf("%% NSH v%s\n", vers);
+	interactive_mode = isatty(STDIN_FILENO);
+	if (interactive_mode) {
+		editing = 1;
+
+		if (getuid() != 0) {
+			printf("%% Functionality is limited without "
+			    "root privileges.\n%% The 'enable' command "
+			    "will switch to the root user.\n");
+		}
+
+		if (!privexec)
+			printf("%% NSH v%s\n", vers);
+	}
 
 	/* create temporal tables (if they aren't already there) */
 	if (db_create_table_rtables() < 0)
@@ -139,7 +145,7 @@ main(int argc, char *argv[])
 		 */
 		carplock(128);
 
-		cmdrc(rc);
+		cmdrc(rc, 0);
 
 		/*
 		 * Initialization over
@@ -154,7 +160,7 @@ main(int argc, char *argv[])
 		 */
 		priv = 1;
 
-		cmdrc(rc);
+		cmdrc(rc, 0);
 
 		exit(0);
 	}

--- a/nsh.8
+++ b/nsh.8
@@ -99,6 +99,16 @@ allows the administrator to view and edit all configuration in one place.
 When
 .Nm
 is run without arguments it loads an interactive shell.
+If standard input is not connected to a terminal
+.Nm
+enters non-interactive mode.
+Multiple commands may be passed on standard input and must be seperated by
+newlines:
+.Bd -literal -offset indent
+# printf "hostname\\nshow ip\\nwho" | nsh
+.Ed
+.Pp
+Some commands which may not work as expected in non-interactive mode.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
@@ -108,12 +118,18 @@ Produce verbose output
 Execute the command(s) in the
 .Ar config-script-file .
 This is typically used to implement scripted changes to configuration.
+This option is incompatible with the
+.Fl i
+option and commands passed on the command line.
 .It Fl i Ar rcfile
 Load the initial system configuration from the command(s) in the
 .Ar rcfile .
 This is typically used to clear the configuration and load a full
 .Nm
 configuration script from rcfile .
+This option is incompatible with the
+.Fl c
+option and commands passed on the command line.
 .It Fl e
 Start
 .Nm
@@ -1716,6 +1732,113 @@ The
 command is an alias for the
 .Cm crontab
 command described above.
+.Pp
+.Tg runat
+.Ic runat Ar time-of-day Ar date Ar command Oo Ar \; command \; ... Oc
+.Pp
+Run a sequence of commands as a background job at some time in the future.
+If multiple commands are given they must be separated by semicolons.
+Commands in the list may be any of the commands supported by
+.Nm .
+In privileged mode the
+.Cm !
+command can be used to run arbitrary Unix commands.
+.Pp
+Command output will be sent via email to the invoking user on the local system.
+The
+.Xr mail 1
+command can be used to read local mail.
+Output will be mailed to other systems if
+.Xr smtpd 8
+and
+.Xr aliases 5
+are configured appropriately.
+.Pp
+.Cm runat
+is based on
+.Xr at 1
+and hence allows some moderately complex
+.Ar time-of-day
+and
+.Ar date
+specifications.
+It accepts times of the form
+.Ar HHMM
+or
+.Ar HH:MM
+to run a job at a specific time of day.
+It is also possible to specify
+.Cm midnight ,
+.Cm noon ,
+or
+.Cm teatime
+(4pm),
+or have a time-of-day suffixed with
+.Cm AM
+or
+.Cm PM
+for running in the morning or the evening.
+To say what day the job will be run,
+give a date in the form
+.Ar \%month-name day
+with an optional
+.Ar year ,
+or giving a date of the form
+.Ar dd.mm.ccyy ,
+.Ar dd.mm.yy ,
+.Ar mm/dd/ccyy ,
+.Ar mm/dd/yy ,
+.Ar mmddccyy ,
+or
+.Ar mmddyy .
+.Pp
+The year may be given as two or four digits.
+If the year is given as two digits, it is taken to occur as soon as
+possible in the future, which may be in the next century \(em
+unless the year is last year, in which case it is considered to be
+a typing error.
+.Pp
+The specification of a
+.Ar date
+must follow the specification of
+the time of day.
+A time like
+.Oo Cm now Oc Cm + Ar count time-units
+may be given,
+where the time-units can be
+.Cm minutes ,
+.Cm hours ,
+.Cm days ,
+.Cm weeks ,
+.Cm months ,
+or
+.Cm years
+(the singular forms are also accepted).
+To run the job today or tomorrow,
+set the
+.Ar date
+parameter to
+.Cm today
+or
+.Cm tomorrow .
+The
+.Cm next
+keyword may be used as an alias for
+.Cm + 1 .
+.Pp
+If the
+.Ar time-of-day
+or
+.Ar date
+arguments contain whitespace they must be enclosed in double-quotes.
+For example, to run a job at 4pm three days from now, use
+.Dq 4pm + 3 days .
+To run a job at 10:00am on July 31, use
+.Dq 10am Jul 31 .
+To run a job at 1am tomorrow, use
+.Dq 1am tomorrow .
+To run a job at midnight in one week's time, use
+.Dq midnight next week .
 .Pp
 .Tg reboot
 .Ic reboot
@@ -4842,6 +4965,7 @@ privileged shell profile
 .El
 .Sh SEE ALSO
 .Bd -ragged -offset indent
+.Xr at 1 ,
 .Xr ed 1 ,
 .Xr mg 1 ,
 .Xr stty 1 ,


### PR DESCRIPTION
Add a runat command, which based on at(1), to allow nsh commands to be run at some time in the future. The name "runat" instead of "at" was chosen to avoid conflicts with future commands that begin with "at" (like we saw when "pin" and "ping" when we had to rename the former to "setpin" to disambiguate the two).

To allow for runat to work without having to store nsh commands in a temporary file which would never get removed, extend the nsh command line interface. We now allow an arbitrary list of nsh commands to be provided on the command line if the -i and -c options are not used.

In privileged mode it is possible to use a ! command on the command line to insert arbitrary shell commands within the list of nsh commands to run.

For ease of use, the runat command supports tab-completion for some variants of the timespec syntax of at(1). It does not attempt to tab-complete the list of commands, however, as this would be much too complicated.

Some basic verification of commands to run is performed before a job gets scheduled. For now, we make sure that an internal or external command to run actually exists, and that commands which require privileged mode are scheduled in privileged mode.
More verification could be added later as needed.