### PR TITLE
! without arguments should not fork a new shell

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1252,7 +1252,7 @@ struct intlist Bridgelist[] = {
 	{ "manual",	manhelp,				CMPL(H) (char **)mantab, sizeof(struct ghs), int_manual, 0 },
 	{ "help",	0,					CMPL0 0, 0, int_help, 0 },
 	{ "exit",	"Leave bridge config mode and return to global config mode ",
-								CMPL0 0, 0, int_exit },
+								CMPL0 0, 0, int_exit, 0 },
 	{ 0, 0, 0, 0, 0, 0 }
 };
 

--- a/commands.c
+++ b/commands.c
@@ -1652,8 +1652,13 @@ int_manual(char *ifname, int ifs, int argc, char **argv)
 static int
 int_shell(char *ifname, int ifs, int argc, char **argv)
 {
-	shell(argc, argv);
-	return 0; /* do not leave interface context */
+	if (argc >1) 
+	{
+		shell(argc, argv);
+		return 0; /* do not leave interface context after execution */
+	}
+	else
+	return 1; /* this is to allow for pasting configs with "!" separators */
 }
 
 static int
@@ -1757,7 +1762,7 @@ static char
 	setenvhelp[] =	"Set an environment variable",
 	unsetenvhelp[] ="Delete an environment variable",
 	saveenvhelp[] =	"Save environment variables set by setenv to ~/.nshenv",
-	shellhelp[] =	"Invoke a subshell",
+	shellhelp[] =	"Invoke a subshell or run an executable",
 	savehelp[] =	"Save the current configuration",
 	nreboothelp[] =	"Reboot the system",
 	halthelp[] =	"Halt the system",
@@ -2365,8 +2370,10 @@ shell(int argc, char **argv)
 	sigint = signal(SIGINT, SIG_IGN);
 	sigquit = signal(SIGQUIT, SIG_IGN);
 	sigchld = signal(SIGCHLD, SIG_DFL);
-
-	switch(child = fork()) {
+        if (argc <= 1) /* only fork if you have a command or shell to execute*/
+		return 1;
+	else {
+		switch(child = fork()) {
 		case -1:
 			printf("%% fork failed: %s\n", strerror(errno));
 			break;
@@ -2384,14 +2391,10 @@ shell(int argc, char **argv)
 			 */
 			char *shellp;
 			char *shellname = shellp = "/bin/sh";
-
-			if (argc > 1)
-				execl(shellp, shellname, "-c", &saveline[1],
-				    (char *)NULL);
-			else
-				execl(shellp, shellname, (char *)NULL);
+			execl(shellp, shellname, "-c", &saveline[1],
+				(char *)NULL);
 			printf("%% execl '%s' failed: %s\n", shellp,
-			    strerror(errno));
+				strerror(errno));
 			_exit(0);
 			}
 			break;
@@ -2399,7 +2402,7 @@ shell(int argc, char **argv)
 			signal(SIGALRM, sigalarm);
  			wait(0);  /* Wait for shell to complete */
 			break;
-	}
+		}
 
 	signal(SIGINT, sigint);
 	signal(SIGQUIT, sigquit);
@@ -2408,6 +2411,8 @@ shell(int argc, char **argv)
 	child = -1;
 
 	return 1;
+	}	
+	
 }
 
 /*

--- a/nsh.8
+++ b/nsh.8
@@ -398,7 +398,7 @@ nsh(p)/help
   verbose       Set verbose diagnostics
   editing       Set command line editing
   who           Display system users
-  !             Invoke a subshell
+  !             Invoke a subshell or run an executable
   ?             Print help information
   quit          Close current connection
 nsh(p)/
@@ -694,7 +694,7 @@ nsh(bridge-bridge100)/?
   who           Display system users
   verbose       Set verbose diagnostics
   editing       Set command line editing
-  !             Invoke a subshell
+  !             Invoke a subshell or run an executable
   ?             Options
   manual        Display the NSH manual
   exit          Leave bridge config mode and return to global config mode
@@ -2988,14 +2988,27 @@ nsh(p)/no editing
 .Tg sh
 .Tg csh
 .Ic nsh(p)/!
-.Op Cm shell-command
-.Ar argument-1
+.Ar Cm shell-command
+.Op argument-1
 .Op Ar argument-n
 .Pp
-Invoke a shell or run an entered shell-command with arguments if required.
+Invoke a shell or run an entered executable with arguments if required.
 (requires privileged mode).
 The active users login shell is the shell that is invoked by this feature.
-This feature disabled to enhance security.
+This feature can be disabled to restrict users from starting a different
+shell or executable from
+.Nm
+.
+If ! is entered without arguments in privilaged mode or global config mode,
+no operation will be carried out and the user will be returned to the same
+.Nm
+command prompt.
+If ! is entered without arguments in interface or bridge config mode the, 
+no operation will be carried out but the user will be returned to the global
+configuration mode.
+This is to facilitate users interactively copying and pasting
+.Nm
+configurations between devices which would contain the "!" spacing character.
 .Pp
 E.g. list files in /root
 .Bd -literal -offset indent
@@ -3004,9 +3017,9 @@ nsh(p)/!ls /root
 helloworld.c
 helloworld2.c
 
-nsh(p)/!
+nsh(p)/!ksh
 
-OpenBSDshell#
+kshprompt#
 .Ed
 .Pp
 .Tg ip
@@ -3398,7 +3411,7 @@ nsh(interface-em0)/?
   who              Display system users
   verbose          Set verbose diagnostics
   editing          Set command line editing
-  !                Invoke a subshell
+  !                Invoke a subshell or run an executable
   ?                Options
   manual           Display the NSH manual
   exit             Leave interface config mode and return to global config mode


### PR DESCRIPTION
This Diff changes the behaviour of nsh interactively by checking if ! has been entered without any arguments,  if the user is in global config mode or privileged mode the user is returned to the same prompt. if the user is in interface config mode or bridge config mode  the user is returned to the global configuration  mode  This is to facilitate users copying and pasting nshrc configuration from one device to another interactively.