### PR TITLE
Null pointer passed as 2nd argument to string copy function

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -1178,8 +1178,14 @@ bridge_addaddr(int s, char *brdg, char *ifname, char *addr)
 	struct ether_addr *ea;
 
 	strlcpy(ifba.ifba_name, brdg, sizeof(ifba.ifba_name));
-	strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
-
+	if(ifname == NULL) {
+		printf("%% Invalid ifname : %s\n", addr);
+		 strerror(errno);
+                return (EX_IOERR);
+	}
+	else {
+		strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
+	}
 	ea = ether_aton(addr);
 	if (ea == NULL) {
 		printf("%% Invalid address: %s\n", addr);


### PR DESCRIPTION
Bug reported by the clang static analyzer.

Description: Null pointer passed as 2nd argument to string copy function
File: /home/tom/nsh-master/nsh/bridge.c
Line: 1181

Proposed fix checks for Null on 2nd argument before calling the strlcopy function