### PR TITLE
Bug pfsync.c fix

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -1178,14 +1178,8 @@ bridge_addaddr(int s, char *brdg, char *ifname, char *addr)
 	struct ether_addr *ea;
 
 	strlcpy(ifba.ifba_name, brdg, sizeof(ifba.ifba_name));
-	if(ifname == NULL) {
-		printf("%% Invalid ifname : %s\n", addr);
-		 strerror(errno);
-                return (EX_IOERR);
-	}
-	else {
-		strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
-	}
+	strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
+
 	ea = ether_aton(addr);
 	if (ea == NULL) {
 		printf("%% Invalid address: %s\n", addr);

--- a/bridge.c
+++ b/bridge.c
@@ -1178,8 +1178,14 @@ bridge_addaddr(int s, char *brdg, char *ifname, char *addr)
 	struct ether_addr *ea;
 
 	strlcpy(ifba.ifba_name, brdg, sizeof(ifba.ifba_name));
-	strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
-
+	if(ifname == NULL) {
+		printf("%% Invalid ifname : %s\n", addr);
+		 strerror(errno);
+                return (EX_IOERR);
+	}
+	else {
+		strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
+	}
 	ea = ether_aton(addr);
 	if (ea == NULL) {
 		printf("%% Invalid address: %s\n", addr);

--- a/pfsync.c
+++ b/pfsync.c
@@ -77,10 +77,17 @@ intsyncdev(char *ifname, int ifs, int argc, char **argv)
 		}
 
 	if (set) {
-		strlcpy(preq.pfsyncr_syncdev, argv[0],
-			sizeof(preq.pfsyncr_syncdev));
-		set_ifflag(ifs, ifname, IFF_UP);
-	} else
+		if (argv[0] != NULL) { 		
+			strlcpy(preq.pfsyncr_syncdev, argv[0],
+				sizeof(preq.pfsyncr_syncdev));
+			set_ifflag(ifs, ifname, IFF_UP);
+		}
+		else {
+			printf("%% Invalid synchronization interface: %s\n",
+				strerror(errno));	
+		}
+	} 
+	else
 		bzero((char *) &preq.pfsyncr_syncdev,
 		      sizeof(preq.pfsyncr_syncdev));
 


### PR DESCRIPTION
Bug reported by the clang static analyzer.

Description: Null pointer passed as 2nd argument to string copy function
File: /home/tom/nsh-master/nsh/pfsync.c
Line: 80

excuse the changes and roll back to bridge.c  they are rolled back to allow one pull request per branch per bug being squashed 
Thanks 