### PR TITLE
Ndp.c fix Branch condition evaluates to a garbage value if(!nbi)

### DIFF
--- a/bridge.c
+++ b/bridge.c
@@ -1178,14 +1178,8 @@ bridge_addaddr(int s, char *brdg, char *ifname, char *addr)
 	struct ether_addr *ea;
 
 	strlcpy(ifba.ifba_name, brdg, sizeof(ifba.ifba_name));
-	if(ifname == NULL) {
-		printf("%% Invalid ifname : %s\n", addr);
-		 strerror(errno);
-                return (EX_IOERR);
-	}
-	else {
-		strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
-	}
+	strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
+
 	ea = ether_aton(addr);
 	if (ea == NULL) {
 		printf("%% Invalid address: %s\n", addr);

--- a/bridge.c
+++ b/bridge.c
@@ -1178,8 +1178,14 @@ bridge_addaddr(int s, char *brdg, char *ifname, char *addr)
 	struct ether_addr *ea;
 
 	strlcpy(ifba.ifba_name, brdg, sizeof(ifba.ifba_name));
-	strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
-
+	if(ifname == NULL) {
+		printf("%% Invalid ifname : %s\n", addr);
+		 strerror(errno);
+                return (EX_IOERR);
+	}
+	else {
+		strlcpy(ifba.ifba_ifsname, ifname, sizeof(ifba.ifba_ifsname));
+	}
 	ea = ether_aton(addr);
 	if (ea == NULL) {
 		printf("%% Invalid address: %s\n", addr);

--- a/ndp.c
+++ b/ndp.c
@@ -522,7 +522,10 @@ ndpdump(struct sockaddr_in6 *addr, int cflag)
 
 			isrouter = nbi->isrouter;
 			prbs = nbi->asked;
-		} else {
+		} 
+		else {
+			printf("\n%% %s: failed to get neighbor information\n",
+                    routename6(sin));
 			printf("  ");
 		}
 
@@ -536,10 +539,6 @@ ndpdump(struct sockaddr_in6 *addr, int cflag)
 
 		printf("\n");
 	}
-
-	if (!nbi)
-		printf("\n%% %s: failed to get neighbor information\n",
-		    routename6(sin));
 
 	free(buf);
 }


### PR DESCRIPTION
Bug reported by the clang static analyzer.

Description: Branch condition evaluates to a garbage value
File: /home/tom/nsh-master/nsh/ndp.c
Line: 540

I compared ndp.c in nsh with ndp.c in  opensd src.. I noticed that they do an 

if(nbi)
and else
rather than 
2 opposing if conditions 
so i went with that and moved the contents if if(!nbi) to the else block under if (nbi)
