### PR TITLE
Remove legacy #ifdef blocks for 6.9 and older  ...

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1099,9 +1099,7 @@ struct intlist Intlist[] = {
 	{ "inet",	"IPv4/IPv6 addresses",			CMPL(h) (char **)intiphelp, sizeof(struct ghs), intip, 1 },
 	{ "ip",		"Alias for \"inet\" command",		CMPL(h) (char **)intiphelp, sizeof(struct ghs), intip, 1 },
 	{ "alias",	NULL, /* backwards compatibilty */	CMPL(h) (char **)intiphelp, sizeof(struct ghs), intip, 1 },
-#ifdef IFXF_AUTOCONF4		/* 6.6+ */
 	{ "autoconf4",  "IPv4 Autoconfigurable address (DHCP)",	CMPL0 0, 0, intxflags, 1 },
-#endif
 	{ "description", "Interface description",		CMPL0 0, 0, intdesc, 1 },
 	{ "group",	"Interface group",			CMPL0 0, 0, intgroup, 1 },
 	{ "rdomain",	"Interface routing domain",		CMPL0 0, 0, intrdomain, 1 },
@@ -1170,16 +1168,9 @@ struct intlist Intlist[] = {
 	{ "mpls",	"MPLS",					CMPL0 0, 0, intxflags, 1 },
 	{ "inet6",	"IPv6 addresses",			CMPL(h) (char **)intip6help, sizeof(struct ghs), intip, 1 },
 	{ "autoconf6",  "IPv6 Autoconfigurable address",	CMPL0 0, 0, intxflags, 1 },
-#ifdef IFXF_INET6_NOPRIVACY	/* pre-6.9 */
-	{ "autoconfprivacy", "Privacy addresses for IPv6 autoconf", CMPL0 0, 0, intxflags, 1 },
-#endif
-#ifdef IFXF_AUTOCONF6TEMP	/* 6.9+ */
 	{ "autoconfprivacy", "Privacy addresses for IPv6 autoconf", CMPL0 0, 0, intxflags, 1 }, /* XXX bkcompat */
 	{ "temporary",	"Temporary addresses for IPv6 autoconf", CMPL0 0, 0, intxflags, 1 },
-#endif
-#ifdef IFXF_MONITOR		/* 6.9+ */
 	{ "monitor",	"Monitor mode for incoming traffic",	CMPL0 0, 0, intxflags, 1 },
-#endif
 	{ "wgpeer",	"Wireguard peer config",		CMPL0 0, 0, intwgpeer, 1 },
 	{ "wgport",	"Wireguard UDP port",			CMPL0 0, 0, intwg, 1 },
 	{ "wgkey",	"Wireguard private key",		CMPL0 0, 0, intwg, 1 },

--- a/conf.c
+++ b/conf.c
@@ -534,7 +534,6 @@ dhcpleased_has_defaultroute(struct sockaddr_rtlabel *sr)
 int
 dhcpleased_controls_interface(char *ifname, int ifs)
 {
-#ifdef IFXF_AUTOCONF4		/* 6.6+ */
 	int ifxflags;
 
 	if (!dhcpleased_is_running())
@@ -542,9 +541,6 @@ dhcpleased_controls_interface(char *ifname, int ifs)
 
 	ifxflags = get_ifxflags(ifname, ifs);
 	return ((ifxflags & IFXF_AUTOCONF4) != 0);
-#else
-	return 0;
-#endif
 }
 
 /*
@@ -988,18 +984,10 @@ void conf_ifxflags(FILE *output, int ifs, char *ifname)
 			fprintf(output, " mpls\n");
 		if (ifr.ifr_flags & IFXF_AUTOCONF6)
 			fprintf(output, " autoconf6\n");
-#ifdef IFXF_INET6_NOPRIVACY	/* pre-6.9 */
-		if (ifr.ifr_flags & IFXF_INET6_NOPRIVACY)
-			fprintf(output, " no autoconfprivacy\n");
-#endif
-#ifdef IFXF_AUTOCONF6TEMP	/* 6.9+ */
 		if (ifr.ifr_flags & IFXF_AUTOCONF6TEMP)
 			fprintf(output, " temporary\n");
-#endif
-#ifdef IFXF_MONITOR		/* 6.9+ */
 		if (ifr.ifr_flags & IFXF_MONITOR)
 			fprintf(output, " monitor\n");
-#endif
 		if (ifr.ifr_flags & IFXF_WOL)
 			fprintf(output, " wol\n");
 	}

--- a/if.c
+++ b/if.c
@@ -643,16 +643,13 @@ show_autoconf(int argc, char **argv)
 	for (ifnp = ifn_list; ifnp->if_name != NULL; ifnp++) {
 		if (ifname && strcmp(ifname, ifnp->if_name) != 0)
 			continue;
-
 		ifxflags = get_ifxflags(ifnp->if_name, ifs);
-#ifdef IFXF_AUTOCONF4		/* 6.6+ */
 		if ((ifxflags & IFXF_AUTOCONF4) && dhcpleased_is_running()) {
 			char *args[] = { DHCPLEASECTL, "-l",
 			    ifnp->if_name, NULL };
 			cmdargs_output(DHCPLEASECTL, args, fd, nullfd);
 			have_output = 1;
 		}
-#endif
 		if ((ifxflags & IFXF_AUTOCONF6) && slaacd_is_running()) {
 			char *args[] = { SLAACCTL, "show", "interface",
 			    ifnp->if_name, NULL };
@@ -2522,26 +2519,16 @@ intxflags(char *ifname, int ifs, int argc, char **argv)
 		set = 1;
 
 	if (isprefix(argv[0], "autoconfprivacy")) {
-#ifdef IFXF_INET6_NOPRIVACY	/* pre-6.9 */
-		value = -IFXF_INET6_NOPRIVACY;
-#endif
-#ifdef IFXF_AUTOCONF6TEMP	/* 6.9+ */
 		value = IFXF_AUTOCONF6TEMP;
 	} else if (isprefix(argv[0], "temporary")) {
 		value = IFXF_AUTOCONF6TEMP;
-#endif
-#ifdef IFXF_MONITOR		/* 6.9+ */
 	} else if (isprefix(argv[0], "monitor")) {
 		value = IFXF_MONITOR;
-#endif
-#ifdef IFXF_AUTOCONF4		/* 6.6+ */
 	} else if (isprefix(argv[0], "autoconf4")) {
 		/* Have "autoconf4" on pppoe(4) do the right thing. */
 		if (is_pppoe(ifname, ifs))
 			return run_ipcp(ifname, ifs, set);
-
 		value = IFXF_AUTOCONF4;
-#endif
 	} else if (isprefix(argv[0], "autoconf6")) {
 		value = IFXF_AUTOCONF6;
 	} else if (isprefix(argv[0], "mpls")) {


### PR DESCRIPTION
Remove legacy #ifdef blocks for 6.9 and older  ...  simplifies  management going forward while keeping a decent amount of backward compatibility ... 3+ years still supported 