### PR TITLE
enable show log functionality  to view  log-files

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -364,6 +364,28 @@ struct prot1 ldcs[] = {
 	{ 0, 0, { 0 } }
 };
 
+struct prot1 logcs[] = {
+        { "authlog",        "/var/log/authlog",                                            
+            { TAIL,  "-n", "100", "/var/log/authlog", NULL, NULL } },
+	{ "daemon",	    "/var/log/daemon",
+            { TAIL,  "-n", "100", "/var/log/daemon", NULL, NULL } },
+        { "dmesg",          "the system messages",
+            { DMESG, NULL, NULL, NULL, NULL, NULL } },
+	{ "console-dmesg",  "startup & console messages",
+            { DMESG, "-s", NULL, NULL, NULL, NULL } },
+	{ "maillog",	    "/var/log/maillog",                                            
+            { TAIL,  "-n", "100", "/var/log/maillog", NULL, NULL } },
+	{ "messages",	    "/var/log/messages",
+            { TAIL, "-n", "100", "/var/log/messages", NULL, NULL } },
+        { "secure", 	    "/var/log/authlog",
+            { TAIL, "-n", "100", "/var/log/authlog", NULL, NULL } },
+        { "security",	     "/var/log/security.out",
+            { TAIL, "-n", "100", "/var/log/security.out", NULL, NULL } },
+                { 0, 0, { 0 } }
+};
+
+
+
 extern struct prot1 bgcs[];
 
 /* show yyy zzz */
@@ -381,6 +403,7 @@ struct prot prots[] = {
 	{ "relay",	rlcs },
 	{ "smtp",	smcs },
 	{ "ldap",	ldcs },
+	{ "log", 	logcs },
 	{ 0,		0 }
 };
 
@@ -463,6 +486,7 @@ Menu showlist[] = {
 	{ "monitor",	"Monitor routing/arp table changes", CMPL0 0, 0, 0, 0, monitor },
 	{ "version",	"Software information",	CMPL0 0, 0, 0, 0, version },
 	{ "users",	"System users",		CMPL0 0, 0, 0, 0, who },
+	{ "log",    "display specified log file", CMPL(ta) (char **)logcs, sizeof(struct prot1), 1, 2, pr_prot1 },
 	{ "crontab",	"Scheduled background jobs",	CMPL0 0, 0, 0, 0, pr_crontab },
 	{ "scheduler",	"Scheduled background jobs",	CMPL0 0, 0, 0, 0, pr_crontab },
 	{ "running-config",	"Operating configuration", CMPL0 0, 0, 0, 0, pr_conf },
@@ -3446,6 +3470,8 @@ pr_crontab(int argc, char **argv, FILE *outfile)
 
 	return 0;
 }
+
+
 
 int
 pr_routes(int argc, char **argv)

--- a/externs.h
+++ b/externs.h
@@ -176,6 +176,8 @@ extern pid_t child;
 #define CLEAR		"/usr/bin/clear"
 #define PING		"/sbin/ping"
 #define PING6		"/sbin/ping6"
+#define DMESG		"/sbin/dmesg"
+#define TAIL		"/usr/bin/tail"
 #define TRACERT		"/usr/sbin/traceroute"
 #define TRACERT6	"/usr/sbin/traceroute6"
 #define TELNET		"/usr/bin/telnet"
@@ -577,6 +579,7 @@ int mbsavis(char**, int *, const char *);
 
 /* ctlargs.c */
 int pr_prot1(int, char **);
+int pr_protandfree(int, char**);
 char **step_optreq(char **, char **, int, char **, int);
 
 /* hashtable.c */

--- a/nsh.8
+++ b/nsh.8
@@ -1854,10 +1854,15 @@ nsh/no verbose
 .El
 .Tg show
 .Ic show
-.Op hostname | interface | autoconf | ip | inet | inet6 | route | route6\
- | sadb | arp | ndp | vlan | kernel | bgp | ospf | ospf6 | pf | eigrp | rip\
- | ldp | ike | ipsec | dvmrp | relay | dhcp | smtp | ldap | monitor\
- | version | users | crontab | running-config | startup-config |\&? | help
+.Op \&? | dvmrp | ip | ospf6 | smtp\
+ | active-config | eigrp | ipsec | pf | startup-config\
+ | arp | enviornment | kernel | relay | users\
+ | autoconf | help | ldap | rip | version\
+ | bgp | hostname | ldp | route | vlan\
+ | bridge | ike | log | route6\
+ | crontab | inet | monitor | running-config\
+ | dhcp | inet6 | ndp | sadb\
+ | diff-config | interface | ospf | scheduler
 .Pp
 The main diagnostic and informational command is 'show'.
 show without arguments  displays the available diagnostic show sub commands.
@@ -1865,7 +1870,7 @@ show without arguments  displays the available diagnostic show sub commands.
 .It
 E.g using show and its built in help
 .Bd -literal -offset indent
-nsh(p)/show
+nsh(p)//show
 % Commands may be abbreviated.
 % 'show' commands are:
 
@@ -1900,9 +1905,14 @@ nsh(p)/show
   monitor         Monitor routing/arp table changes
   version         Software information
   users           System users
+  log             display specified log file
   crontab         Scheduled background jobs
+  scheduler       Scheduled background jobs
   running-config  Operating configuration
   startup-config  Startup configuration
+  active-config   Configuration of active context
+  diff-config     Show differences between startup and running config
+  environment     Show environment variables
   ?               Options
 nsh(p)/
 .Ed
@@ -2367,7 +2377,8 @@ nsh(p)/show bridge tpmr102
 .Tg mbuf
 .Tg pf
 .Ic show kernel
-.Op Ar ip | ah | esp | tcp | icmp | igmp | ipcomp | route | carp | mbuf | pf
+.Op Ar ip | ah | esp | tcp | icmp | igmp\
+ | ipcomp | route | carp | mbuf | pf
 .Pp
 Display kernel statistics available for query.
 Display kernel statistics as selected by the argument.
@@ -2700,6 +2711,50 @@ cpu: Intel(R) Core(TM) i7-10610U CPU @ 1.80GHz
 memory: 8175MB
 kernel: OpenBSD 7.1 (GENERIC.MP) #459: Mon Apr  4 18:16:13 MDT 2022
     deraadt@amd64.openbsd.org:/usr/src/sys/arch/amd64/compile/GENERIC.MP
+.Ed
+.Pp
+.Tg show
+.Tg user
+.Tg who
+.Ic show users
+.Pp
+Display the active system users similar to the command
+.Xr who 1 .
+manual page for more information.
+.Pp
+.Tg log
+.Tg syslog
+.Tg message
+.Tg tail
+.Tg cat
+.Tg dmesg
+.Tg show
+.Ic show log
+.Op \&? |authlog | daemon | dmesg | console-dmesg\
+ | maillog | messages | secure | security
+.Pp
+show the last 100 lines of the selected log file.
+Most of the
+.Cm show log
+commands use the standard
+.Xr tail 1
+commmand.
+The dmesg logs are displayed using the
+.Xr dmesg 8
+command.
+.Bd -literal -offset indent
+nsh(config-p)/show log ?
+% Arguments may be abbreviated
+
+  show log authlog       /var/log/authlog information
+  show log daemon        /var/log/daemon information
+  show log dmesg         the system messages information
+  show log console-dmesg startup & console messages information
+  show log maillog       /var/log/maillog information
+  show log messages      /var/log/messages information
+  show log secure        /var/log/authlog information
+  show log security      /var/log/security.out information
+nsh(config-p)/
 .Ed
 .Pp
 .Ic show crontab


### PR DESCRIPTION
enable show log functionality  to view  log-files
only specified log files are supported for now ...  and only 100 lines displayed (tail -n) except for dmesg functionality (as dmesg files are displayed with dmesg tool  not tail command