### PR TITLE
implement a reload reboot  command alias

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -2039,6 +2039,7 @@ size_t cmdtab_nitems = nitems(cmdtab);
  */
 
 static Command  cmdtab2[] = {
+	{ "reload",     nreboothelp,    CMPL0 0, 0, nreboot,            1, 0, 0, 0 },
 	{ "su",         enablehelp,     CMPL(ta) (char **)enabletab, sizeof(Menu), enable,      0, 0, 0, 0 },
 	{ 0,		0,		CMPL0 0, 0, 0,		0, 0, 0, 0 }
 };

--- a/nsh.8
+++ b/nsh.8
@@ -1864,7 +1864,8 @@ Sep  8 15:05:37 tobsd tom: interface drops due to unprotected devices
 .Ic reboot
 .Pp
 Restart the system.
-.Nm while processing the command will warn the user if there are
+.Nm
+when processing the command will warn the user if there are
 unsaved changes to the running-config.
 The user will be prompted to confirm the reboot in any case.
 The command requires
@@ -1888,7 +1889,8 @@ Proceed with reboot? [yes/no]
 .Ic reload
 .Pp
 an alias for the reboot command above.
-.Nm while processing the command will warn the user if there are
+.Nm
+when processing the command will warn the user if there are
 unsaved changes to the running-config.
 The user will be prompted to confirm the reboot in any case.
 The command requires

--- a/nsh.8
+++ b/nsh.8
@@ -1859,10 +1859,15 @@ Sep  8 15:05:37 tobsd tom: interface drops due to unprotected devices
 .El
 .Pp
 .Tg reboot
+.Tg restart
+.Tg reload
 .Ic reboot
 .Pp
 Restart the system.
-Requires
+.Nm while processing the command will warn the user if there are
+unsaved changes to the running-config.
+The user will be prompted to confirm the reboot in any case.
+The command requires
 .Nm
 to be in privileged mode and requires root user privileges.
 .Bl -dash
@@ -1870,7 +1875,34 @@ to be in privileged mode and requires root user privileges.
 E.g. restart the system
 .Bd -literal -offset indent
 nsh(config-p)/reboot
-% Reboot initiated
+% WARNING: The running configuration contains unsaved changes!
+% The 'show diff-config' command will display unsaved changes.
+% The 'write-config' command will save changes to /etc/nshrc.
+Proceed with reboot? [yes/no]
+.Ed
+.El
+.Pp
+.Tg reboot
+.Tg restart
+.Tg reload
+.Ic reload
+.Pp
+an alias for the reboot command above.
+.Nm while processing the command will warn the user if there are
+unsaved changes to the running-config.
+The user will be prompted to confirm the reboot in any case.
+The command requires
+.Nm
+to be in privileged mode and requires root user privileges.
+.Bl -dash
+.It
+E.g. restart the system
+.Bd -literal -offset indent
+nsh(config-p)/reload
+% WARNING: The running configuration contains unsaved changes!
+% The 'show diff-config' command will display unsaved changes.
+% The 'write-config' command will save changes to /etc/nshrc.
+Proceed with reboot? [yes/no]
 .Ed
 .El
 .Pp


### PR DESCRIPTION
in many router / switching systems the reload command is used to restart the system.  added an alias of the reboot command and improved documentation of reload and reboot commands 