### PR TITLE
Fix KNF non compliance in variable declarations , double semi colons comment styles, and indentation

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -2961,7 +2961,7 @@ group(int argc, char **argv, ...)
 	return 0;
 }
 
-//clear terminal screen
+/* clear terminal screen */
 static int
 clear(int argc, char **argv, ...)
 {

--- a/main.c
+++ b/main.c
@@ -40,8 +40,12 @@ jmp_buf toplevel;
 char *vers = NSH_VERSION_STR;
 int bridge = 0;		/* bridge mode for interface() */
 int verbose = 0;	/* verbose mode */
-int priv = 0, privexec = 0, cli_rtable = 0;
-int editing = 0, interactive_mode = 0, config_mode = 0;;
+int priv = 0;
+int privexec = 0;
+int cli_rtable = 0;
+int editing = 0;
+int interactive_mode = 0;
+int config_mode = 0;
 pid_t pid;
 
 History *histi = NULL;

--- a/tunnel.c
+++ b/tunnel.c
@@ -63,7 +63,7 @@ intvnetid(int argc, char **argv, ...)
 		printf("%% vnetid <vnetid>\n");
 		printf("%% no vnetid [vnetid]\n");
 		return 0;
-        }
+	}
 	if (set)
 		setvnetid(ifs, ifname, argv[0]);
 	else
@@ -381,7 +381,7 @@ get_physrtable(int s, char *ifname)
 	strlcpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
 	if (ioctl(s, SIOCGLIFPHYRTABLE, (caddr_t)&ifr) < 0)
 		return 0;
-        else
+	else
 		return ifr.ifr_rdomainid;
 }
 


### PR DESCRIPTION
Fix Multiple variable declartions on one line -> one declaration per line, remove double semicolon  at the end of line in main.c,  fix indenttion issue in tunnel.c , fix // comment and replace with /* comment */