### PR TITLE
Knf includes sys std net

### DIFF
--- a/arp.c
+++ b/arp.c
@@ -33,29 +33,33 @@
  */
 
 #include <sys/file.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/sysctl.h>
-#include <sys/ioctl.h>
 #include <sys/time.h>
+
 #include <net/bpf.h>
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/if_types.h>
 #include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
+
 #include <arpa/inet.h>
 
-#include <netdb.h>
-#include <errno.h>
 #include <err.h>
+#include <errno.h>
+#include <ifaddrs.h>
+#include <limits.h>
+#include <netdb.h>
+#include <paths.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <paths.h>
 #include <unistd.h>
-#include <limits.h>
-#include <ifaddrs.h>
+
 #include "externs.h"
 
 /* ROUNDUP() is nasty, but it is identical to what's in the kernel. */

--- a/bgpcommands.c
+++ b/bgpcommands.c
@@ -15,10 +15,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>	/* MAXHOSTNAMELEN */
-#include <net/if.h>	/* IFNAMSIZ */
-
+#include <sys/param.h>
 #include <sys/types.h>
+
+#include <net/if.h>
 
 #include <limits.h>
 #include <stdio.h>

--- a/bridge.c
+++ b/bridge.c
@@ -26,27 +26,31 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <stdint.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
+#include <sys/types.h>
+
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/if_types.h>
+
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
+
 #include <net/if_bridge.h>
-#include <errno.h>
-#include <string.h>
+
 #include <err.h>
-#include <sysexits.h>
-#include <stdlib.h>
+#include <errno.h>
 #include <limits.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sysexits.h>
+#include <unistd.h>
+
 #include "externs.h"
 #include "bridge.h"
 

--- a/carp.c
+++ b/carp.c
@@ -14,21 +14,26 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <sys/ioctl.h>
+#include <sys/limits.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <net/if.h>
+
+#include <netinet/in.h>
+#include <netinet/ip_carp.h>
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <netdb.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <string.h>
-#include <errno.h>
-#include <sys/limits.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netinet/ip_carp.h>
-#include <net/if.h>
-#include <netdb.h>
 #include <unistd.h>
+
 #include "externs.h"
 
 static struct intc {

--- a/cmdargs.c
+++ b/cmdargs.c
@@ -15,19 +15,19 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>	/* MAXHOSTNAMELEN */
-#include <net/if.h>	/* IFNAMSIZ */
-
-#include <sys/types.h>
+#include <sys/param.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 
+#include <net/if.h>
+
+#include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <signal.h>
-#include <errno.h>
 #include <unistd.h>
 
 #include "externs.h"

--- a/commands.c
+++ b/commands.c
@@ -42,32 +42,36 @@
  * SUCH DAMAGE.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <string.h>
-#include <errno.h>
-#include <signal.h>
-#include <stdarg.h>
 #include <sys/fcntl.h>
-#include <sys/stat.h>
-#include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/reboot.h>
+#include <sys/socket.h>
 #include <sys/sockio.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
-#include <sys/ioctl.h>
+
 #include <net/if.h>
 #include <net/route.h>
+
+#include <ctype.h>
+#include <errno.h>
 #include <limits.h>
-#include <util.h>
 #include <pwd.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <util.h>
+
 #include "editing.h"
 #include "stringlist.h"
 #include "externs.h"
 #include "sysctl.h"
 #include "ctl.h"
+#include "commands.h"
 
 char hname[HSIZE];
 char hbuf[MAXHOSTNAMELEN];	/* host name */
@@ -154,8 +158,6 @@ static int 	powerdown(int, char **, ...);
 static void	pf_stats(void);
 static int	interface(int, char **, ...);
 static int	int_interface(int, char **, ...);
-
-#include "commands.h"
 
 void
 sigalarm(int blahfart)

--- a/complete.c
+++ b/complete.c
@@ -28,19 +28,22 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sys/ioctl.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/tty.h>
+
+#include <net/if.h>
+
+#include <dirent.h>
 #include <err.h>
 #include <errno.h>
-#include <dirent.h>
+#include <ifaddrs.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <ifaddrs.h>
-#include <net/if.h>
-#include <sys/param.h>
-#include <sys/tty.h>
 #include <unistd.h>
+
 #include "editing.h"
 #include "stringlist.h"
 #include "externs.h"

--- a/conf.c
+++ b/conf.c
@@ -14,38 +14,45 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <ctype.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <pwd.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <sys/socket.h>
-#include <sys/param.h>
-#include <sys/sockio.h>
 #include <sys/ioctl.h>
-#include <sys/stat.h>
 #include <sys/limits.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/sockio.h>
+#include <sys/stat.h>
+
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/if_types.h>
+#include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/if_ether.h>
-#include <netinet6/in6_var.h>
-#include <net/if_vlan_var.h>
-#include <net/route.h>
-#include <net/pfvar.h>
-#include <netmpls/mpls.h>
 #include <netinet/ip_ipsp.h>
+#include <netinet6/in6_var.h>
+
+#include <net/if_vlan_var.h>
+#include <net/pfvar.h>
 #include <net/if_pfsync.h>
 #include <net/if_pflow.h>
-#include <netdb.h>
-#include <ifaddrs.h>
+
+#include <netmpls/mpls.h>
+
 #include <arpa/inet.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <ifaddrs.h>
 #include <limits.h>
+#include <netdb.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "stringlist.h"
 #include "externs.h"
 #include "bridge.h"

--- a/ctl.c
+++ b/ctl.c
@@ -14,21 +14,24 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <sys/signal.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syslimits.h>
+#include <sys/types.h>
+
+#include <net/if.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <histedit.h>
+#include <libgen.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <fcntl.h>
 #include <unistd.h>
-#include <errno.h>
-#include <libgen.h>
-#include <histedit.h>
-#include <stdarg.h>
-#include <sys/signal.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/socket.h>
-#include <sys/syslimits.h>
-#include <net/if.h>
+
 #include "externs.h"
 #include "editing.h"
 #include "ctl.h"

--- a/ctlargs.c
+++ b/ctlargs.c
@@ -14,10 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>	/* MAXHOSTNAMELEN */
-#include <net/if.h>	/* IFNAMSIZ */
-
+#include <sys/param.h>
 #include <sys/types.h>
+
+#include <net/if.h>
 
 #include <stdio.h>
 

--- a/helpcommands.c
+++ b/helpcommands.c
@@ -14,10 +14,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>	/* MAXHOSTNAMELEN */
-#include <net/if.h>	/* IFNAMSIZ */
-
+#include <sys/param.h>
 #include <sys/types.h>
+
+#include <net/if.h>
 
 #include <limits.h>
 #include <stdio.h>

--- a/ieee80211.c
+++ b/ieee80211.c
@@ -58,22 +58,27 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
-#include <string.h>
-#include <unistd.h>
-#include <errno.h>
-#include <stdarg.h>
-#include <sys/limits.h>
-#include <sys/socket.h>
 #include <sys/ioctl.h>
+#include <sys/limits.h>
 #include <sys/param.h>
+#include <sys/socket.h>
+
 #include <net/if.h>
+
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
+
 #include <net80211/ieee80211.h>
 #include <net80211/ieee80211_ioctl.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "externs.h"
 
 const char *

--- a/if.c
+++ b/if.c
@@ -14,40 +14,47 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/tree.h>
-
-#include <stdarg.h>
-#include <stdio.h>
-#include <ctype.h>
-#include <fcntl.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <errno.h>
-#include <stdint.h>
-#include <sys/socket.h>
-#include <sys/param.h>
-#include <sys/sockio.h>
 #include <sys/ioctl.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/sockio.h>
+#include <sys/tree.h>
 #include <sys/un.h>
+
 #include <net/if.h>
-#include <net/if_types.h>
 #include <net/if_dl.h>
+#include <net/if_types.h>
 #include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
 #include <netinet6/in6_var.h>
 #include <netinet6/nd6.h>
-#include <netmpls/mpls.h>
-#include <netdb.h>
-#include <net/if_vlan_var.h>
-#include <net/if_pflow.h>
+
 #include <net/if_media.h>
+#include <net/if_pflow.h>
+#include <net/if_vlan_var.h>
+
 #include <net80211/ieee80211.h>
 #include <net80211/ieee80211_ioctl.h>
-#include <ifaddrs.h>
+
+#include <netmpls/mpls.h>
+
 #include <arpa/inet.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <ifaddrs.h>
 #include <limits.h>
+#include <netdb.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "ip.h"
 #include "bridge.h"
 #include "stringlist.h"

--- a/kroute.c
+++ b/kroute.c
@@ -29,31 +29,34 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/param.h>
-#include <sys/socket.h>
+#include <sys/types.h>
 #include <sys/ioctl.h>
 #include <sys/mbuf.h>
-#include <sys/sysctl.h>
+#include <sys/param.h>
 #include <sys/signal.h>
-#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
 
 #include <net/if.h>
-#include <net/route.h>
 #include <net/if_dl.h>
 #include <net/if_types.h>
+#include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
-#include <arpa/inet.h>
-#include <netdb.h>
 
+#include <arpa/inet.h>
+
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
+#include <netdb.h>
+#include <paths.h>
 #include <stdio.h>
-#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <paths.h>
+#include <unistd.h>
+
 #include "ip.h"
 #define _WANT_SO_
 #include "externs.h"

--- a/main.c
+++ b/main.c
@@ -14,20 +14,22 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <string.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <setjmp.h>
-#include <locale.h>
+#include <sys/signal.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/syslimits.h>
 #include <sys/ttycom.h>
-#include <sys/signal.h>
-#include <sys/stat.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <locale.h>
+#include <setjmp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "editing.h"
 #include "stringlist.h"
 #include "externs.h"

--- a/media.c
+++ b/media.c
@@ -32,20 +32,24 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
+#include <sys/types.h>
+
 #include <net/if.h>
 #include <net/if_media.h>
+
 #include <netinet/in.h>
+
 #include <errno.h>
 #include <netdb.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "externs.h"
 
 int init_current_media(int, char *);

--- a/more.c
+++ b/more.c
@@ -14,15 +14,16 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <termios.h>
-#include <errno.h>
-#include <string.h>
-#include <stdlib.h>
-#include <sys/ttycom.h>
 #include <sys/ioctl.h>
+#include <sys/ttycom.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
 #include <wchar.h>
 
 #include "externs.h"

--- a/ndp.c
+++ b/ndp.c
@@ -93,15 +93,16 @@
 
 #include <arpa/inet.h>
 
-#include <stdio.h>
+#include <err.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <netdb.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <limits.h>
-#include <err.h>
+
 #include "externs.h"
 
 /* packing rule for routing socket */

--- a/passwd.c
+++ b/passwd.c
@@ -24,15 +24,17 @@
  *
  */
 
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <errno.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <errno.h>
-#include <pwd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/socket.h>
+
 #include "externs.h"
 
 int read_pass(char *, size_t);

--- a/pflow.c
+++ b/pflow.c
@@ -32,22 +32,25 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/types.h>
 #include <sys/ioctl.h>
-
 #include <sys/socket.h>
 #include <sys/syslimits.h>
-#include <net/route.h>
+#include <sys/types.h>
+
 #include <net/if.h>
+#include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/in_var.h>
 #include <netinet6/in6_var.h>
 #include <netinet6/nd6.h>
-#include <arpa/inet.h>
+
 #include <net/if_pflow.h>
 
-#include <netdb.h>
+#include <arpa/inet.h>
+
 #include <errno.h>
+#include <netdb.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/pfsync.c
+++ b/pfsync.c
@@ -14,22 +14,28 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <sys/ioctl.h>
+#include <sys/limits.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <net/if.h>
+
+#include <netinet/in.h>
+#include <netinet/ip_ipsp.h>
+
+#include <net/pfvar.h>
+#include <net/if_pfsync.h>
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <netdb.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>
-#include <errno.h>
-#include <sys/limits.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
-#include <sys/ioctl.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <net/if.h>
-#include <net/pfvar.h>
-#include <netinet/ip_ipsp.h>
-#include <net/if_pfsync.h>
+
 #include "externs.h"
 
 #define PFSYNC_MAXUPDATES 128

--- a/ppp.c
+++ b/ppp.c
@@ -14,23 +14,29 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
-#include <errno.h>
-#include <sys/socket.h>
-#include <sys/param.h>
-#include <sys/sockio.h>
 #include <sys/ioctl.h>
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/sockio.h>
+
 #include <net/if.h>
 #include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
-#include <arpa/inet.h>
+
 #include <net/ppp_defs.h>
 #include <net/if_sppp.h>
 #include <net/if_pppoe.h>
+
+#include <arpa/inet.h>
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "ip.h"
 #include "stringlist.h"
 #include "externs.h"

--- a/prompt.c
+++ b/prompt.c
@@ -15,10 +15,10 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <sys/param.h>	/* MAXHOSTNAMELEN */
-#include <net/if.h>	/* IFNAMSIZ */
-
+#include <sys/param.h>
 #include <sys/types.h>
+
+#include <net/if.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/route.c
+++ b/route.c
@@ -14,19 +14,24 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <ctype.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <netdb.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
 #include <sys/sysctl.h>
-#include <netinet/in.h>
+
 #include <net/route.h>
+
+#include <netinet/in.h>
+
 #include <arpa/inet.h>
+
+#include <ctype.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
 #include "ip.h"
 #include "externs.h"
 

--- a/show.c
+++ b/show.c
@@ -29,10 +29,11 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/types.h>
+#include <sys/mbuf.h>
 #include <sys/param.h>
 #include <sys/protosw.h>
 #include <sys/socket.h>
-#include <sys/mbuf.h>
 #include <sys/sysctl.h>
 
 #include <net/if.h>
@@ -40,16 +41,18 @@
 #include <net/if_types.h>
 #include <net/pfkeyv2.h>
 #include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
 #include <netinet/ip_ipsp.h>
+
 #include <arpa/inet.h>
 
 #include <err.h>
 #include <errno.h>
 #include <netdb.h>
-#include <stdio.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/sqlite3.c
+++ b/sqlite3.c
@@ -13,13 +13,15 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-#include <errno.h>
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <sys/socket.h>
 #include <sys/limits.h>
+#include <sys/socket.h>
+
+#include <errno.h>
 #include <sqlite3.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "stringlist.h"
 #include "externs.h"
 

--- a/stats.c
+++ b/stats.c
@@ -29,17 +29,19 @@
  * SUCH DAMAGE.
  */
 
+#include <sys/types.h>
+#include <sys/mbuf.h>
 #include <sys/param.h>
+#include <sys/pool.h>
+#include <sys/protosw.h>
 #include <sys/queue.h>
 #include <sys/socket.h>
 #include <sys/socketvar.h>
-#include <sys/mbuf.h>
-#include <sys/protosw.h>
 #include <sys/sysctl.h>
-#include <sys/pool.h>
-#include <errno.h>
 
+#include <net/if.h>
 #include <net/route.h>
+
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>
@@ -64,17 +66,20 @@
 #include <netinet/ip_ipcomp.h>
 #include <netinet/ip_ether.h>
 #include <netinet/ip_carp.h>
-#include <net/if.h>
+
 #include <net/pfvar.h>
 #include <net/if_pfsync.h>
 
 #include <arpa/inet.h>
+
+#include <errno.h>
 #include <limits.h>
 #include <netdb.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <stdlib.h>
+
 #include "externs.h"
 
 static int sflag = 1;

--- a/sysctl.c
+++ b/sysctl.c
@@ -14,27 +14,33 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <netinet/in.h>
-#include <stdlib.h>
-#include <stdarg.h>
 #include <sys/param.h>
-#include <sys/sysctl.h>
 #include <sys/socket.h>
+#include <sys/sysctl.h>
+
 #include <net/if.h>
-#include <net/pipex.h>
+
 #include <netinet/in.h>
-#include <netinet/ip_ether.h>
-#include <netinet/ip_ipip.h>
-#include <netinet/ip_gre.h>
-#include <netinet/ip_ipcomp.h>
-#include <netinet/ip_esp.h>
 #include <netinet/ip_ah.h>
 #include <netinet/ip_carp.h>
+#include <netinet/ip_esp.h>
+#include <netinet/ip_ether.h>
+#include <netinet/ip_gre.h>
+#include <netinet/ip_ipcomp.h>
+#include <netinet/ip_ipip.h>
+
+#include <net/pipex.h>
+
 #include <netmpls/mpls.h>
+
 #include <ddb/db_var.h>
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "externs.h"
 #include "sysctl.h"
 

--- a/trunk.c
+++ b/trunk.c
@@ -25,18 +25,23 @@
  *
  */
 
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <string.h>
-#include <errno.h>
+#include <sys/ioctl.h>
 #include <sys/limits.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
-#include <netinet/in.h>
+
 #include <net/if.h>
+
+#include <netinet/in.h>
 #include <netinet/if_ether.h>
+
 #include <net/if_trunk.h>
+
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "externs.h"
 
 struct trunk_protos tpr[] = TRUNK_PROTOS;

--- a/tunnel.c
+++ b/tunnel.c
@@ -1,20 +1,23 @@
 /* From: $OpenBSD: /usr/src/sbin/ifconfig/ifconfig.c,v 1.295 2015/01/16 06:39:58 deraadt Exp $ */
 
-#include <stdio.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <errno.h>
-#include <stdint.h>
+#include <sys/ioctl.h>
 #include <sys/param.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
+#include <sys/types.h>
+
 #include <net/if.h>
 #include <net/if_dl.h>
+
 #include <netinet/in.h>
+
+#include <errno.h>
 #include <netdb.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "externs.h"
 

--- a/version.c
+++ b/version.c
@@ -14,16 +14,20 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include <stdio.h>
-#include <ctype.h>
-#include <string.h>
-#include <errno.h>
 #include <sys/param.h>
+#include <sys/socket.h>
 #include <sys/sysctl.h>
 #include <sys/utsname.h>
-#include <sys/socket.h>
+
 #include <net/if.h>
+
 #include <netinet/in.h>
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "externs.h"
 
 int

--- a/wg.c
+++ b/wg.c
@@ -1,20 +1,24 @@
 /* From: $OpenBSD: ifconfig.c,v 1.430 2020/11/06 21:24:47 kn Exp $	*/
 
-#include <stdio.h>
+#include <sys/ioctl.h>
+#include <sys/sockio.h>
+
+#include <net/if_wg.h>
+
+#include <netinet/in.h>
+
+#include <arpa/inet.h>
+
 #include <ctype.h>
+#include <errno.h>
+#include <netdb.h>
+#include <resolv.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>
 #include <time.h>
-#include <sys/sockio.h>
-#include <sys/ioctl.h>
-#include <net/if_wg.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <netdb.h>
-#include <errno.h>
-#include <stddef.h>
-#include <resolv.h>
 
 #include "externs.h"
 

--- a/who.c
+++ b/who.c
@@ -30,15 +30,16 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+
 #include <errno.h>
 #include <paths.h>
 #include <pwd.h>
-#include <utmp.h>
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
+#include <utmp.h>
 
 #include "externs.h"
 


### PR DESCRIPTION
updated ordering of include files to comply with KNF as much as possible,  most standard and net and sys libraries are ordered alphabetically and with a space between each category, there were a hand full of files that still need to be ordered by dependency, 

this diff is a  non functional change just to improve the readability of the code.  