### PR TITLE
Fix high cpu on long uptime machines probably due to lost terminal sessions 

### DIFF
--- a/bgpnsh/bgpnsh.c
+++ b/bgpnsh/bgpnsh.c
@@ -143,20 +143,33 @@ command(void)
 		const char *buf;
 		cursor_pos = NULL;
 
-		if ((buf = el_gets(elc, &num)) == NULL || num == 0)
-			break;
+		if (editing && !isatty(STDIN_FILENO))
+			endedit();
+		if (!isatty(STDIN_FILENO) || elc == NULL) {
+			size_t linelen;
 
-		if (buf[--num]  == '\n') {
-			if (num == 0)
+			if (fgets(line, sizeof(line), stdin) == NULL)
 				break;
+			linelen = strlen(line);
+			while (linelen > 0 && (line[linelen - 1] == '\n' ||
+			    line[linelen - 1] == '\r'))
+				line[--linelen] = '\0';
+		} else {
+			if ((buf = el_gets(elc, &num)) == NULL || num == 0)
+				break;
+
+			if (buf[--num]  == '\n') {
+				if (num == 0)
+					break;
+			}
+			if (num >= sizeof(line)) {
+				printf("%% Input exceeds permitted length\n");
+				break;
+			}
+			memcpy(line, buf, (size_t)num);
+			line[num] = '\0';
+			history(histc, &ev, H_ENTER, buf);
 		}
-		if (num >= sizeof(line)) {
-			printf("%% Input exceeds permitted length\n");
-			break;
-		}
-		memcpy(line, buf, (size_t)num);
-		line[num] = '\0';
-		history(histc, &ev, H_ENTER, buf);
 
 		if (line[0] == 0)
 			break;

--- a/commands.c
+++ b/commands.c
@@ -1571,6 +1571,8 @@ interface(int argc, char **argv, ...)
 	for (;;) {
 		char *margp;
 
+		if (editing && !isatty(STDIN_FILENO))
+			endedit();
 		if (!editing) {
 			/* command line editing disabled */
 			if (interactive_mode)
@@ -2122,6 +2124,8 @@ command()
 			(void)setwinsize(caught_sigwinch);
 			caught_sigwinch = 0;
 		}
+		if (editing && !isatty(STDIN_FILENO))
+			endedit();
 		if (!editing) {
 			if (interactive_mode)
 				printf("%s", cprompt());
@@ -3371,6 +3375,7 @@ static int
 do_reboot(int how)
 {
 	const char *buf;
+	char linebuf[64];
 	int ret = 0, num, have_changes;
 	char *argv[3] = { REBOOT, NULL, NULL };
 
@@ -3413,7 +3418,13 @@ do_reboot(int how)
 	}
 
 	for (;;) {
-		if ((buf = el_gets(elp, &num)) == NULL) {
+		if (!isatty(STDIN_FILENO) || elp == NULL) {
+			if (fgets(linebuf, sizeof(linebuf), stdin) == NULL) {
+				ret = -1;
+				goto done;
+			}
+			buf = linebuf;
+		} else if ((buf = el_gets(elp, &num)) == NULL) {
 			if (num == -1) {
 				ret = -1;
 				goto done;

--- a/complete.c
+++ b/complete.c
@@ -1062,6 +1062,12 @@ endhist()
 void
 initedit()
 {
+	if (!isatty(STDIN_FILENO)) {
+		printf("%% Command line editing requires a terminal\n");
+		editing = 0;
+		return;
+	}
+
 	editing = 1;
 
 	if (!elc) {
@@ -1117,6 +1123,10 @@ endedit()
 	if (eli) {
 		el_end(eli);
 		eli = NULL;
+	}
+	if (elp) {
+		el_end(elp);
+		elp = NULL;
 	}
 }
 

--- a/ctl.c
+++ b/ctl.c
@@ -915,6 +915,7 @@ provide_example_config(char *filename)
 	char tmpprompt[sizeof(prompt)];
 	FILE *f = NULL, *example = NULL;
 	int ret = 0, n, num;
+	char linebuf[64];
 	struct stat sb;
 	size_t len, remain;
 
@@ -972,7 +973,13 @@ provide_example_config(char *filename)
 	for (;;) {
 		const char *buf;
 
-		if ((buf = el_gets(elp, &num)) == NULL) {
+		if (!isatty(STDIN_FILENO) || elp == NULL) {
+			if (fgets(linebuf, sizeof(linebuf), stdin) == NULL) {
+				ret = -1;
+				goto done;
+			}
+			buf = linebuf;
+		} else if ((buf = el_gets(elp, &num)) == NULL) {
 			if (num == -1) {
 				ret = -1;
 				goto done;


### PR DESCRIPTION
Based on  analysis of spinning loop discovered in ktrace on a couple of systems runnning for 5 months or more 

dcfw03# kdump -f ktrace.out  |head -n 100 
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,FIONREAD,0x7edbae176920)
 99072 nsh      RET   ioctl -1 errno 25 Inappropriate ioctl for device
 99072 nsh      CALL  ioctl(0,TIOCGETA,0xf510ef44790)